### PR TITLE
hwc: Release all key presses when the window loses focus.

### DIFF
--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -123,6 +123,7 @@ struct display {
     std::map<uint32_t, struct handleExt> layer_handles_ext;
     struct handleExt target_layer_handle_ext;
     std::map<buffer_handle_t, struct buffer *> buffer_map;
+    std::array<uint8_t, 239> keysDown;
 
     bool isWinResSet;
     sp<IWaydroidTask> task;


### PR DESCRIPTION
This fixes the problem where switching apps causes key presses to be stuck.
(Such as Alt keys, used for Alt + Tab shortcut)

I moved part of key event handler code to another function named `send_key_event`, so that the code for handling key release event can be properly sent when Waydroid window loses focus.

I'm not sure if we need more than 239 keys. I thought we need 239 keys, looking at this code from SDL. xfree86_scancode_table2 is an array with 239 scancodes.
https://github.com/libsdl-org/SDL/blob/120c76c84bbce4c1bfed4e9eb74e10678bd83120/src/video/wayland/SDL_waylandevents.c#L962

Unlike SDL, my implementation currently does not ignore unknown scancodes (SDL ignores scancodes defined as `SDL_UNKNOWN`.

Related: https://github.com/waydroid/waydroid/issues/350