### PR TITLE
gralloc_gbm: Add SCANOUT flag to HW_FB and HW_COMPOSER usages

### DIFF
--- a/gralloc/gralloc_gbm.cpp
+++ b/gralloc/gralloc_gbm.cpp
@@ -153,9 +153,9 @@ static unsigned int get_pipe_bind(int usage)
 	if (usage & (GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_TEXTURE))
 		bind |= GBM_BO_USE_RENDERING;
 	if (usage & GRALLOC_USAGE_HW_FB)
-		bind |= GBM_BO_USE_RENDERING;
+		bind |= GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING;
 	if (usage & GRALLOC_USAGE_HW_COMPOSER)
-		bind |= GBM_BO_USE_RENDERING;
+		bind |= GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING;
 
 	return bind;
 }


### PR DESCRIPTION
Some hardware configurations require the BO to be created with
GBM_BO_USE_SCANOUT in order to make it suitable for display.

This fixes garbled buffer content on Purism Librem 5 and likely
various multi-GPU PC configurations too.