### PR TITLE
hwcomposer: Use dummy buffer as window background in subsurface mode

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -537,14 +537,14 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
         if (active_apps == "Waydroid") {
             // Show everything in a single window
             if (pdev->windows.find(active_apps) == pdev->windows.end()) {
-                pdev->windows[active_apps] = create_window(pdev->display, pdev->use_subsurface, active_apps, "0");
+                pdev->windows[active_apps] = create_window(pdev->display, pdev->use_subsurface, active_apps, "0", {0, 0, 0, 255});
                 property_set("waydroid.open_windows", std::to_string(pdev->windows.size()).c_str());
             }
             window = pdev->windows[active_apps];
         } else if (!pdev->multi_windows) {
             if (single_layer_tid.length()) {
                 if (pdev->windows.find(single_layer_tid) == pdev->windows.end()) {
-                    pdev->windows[single_layer_tid] = create_window(pdev->display, pdev->use_subsurface, single_layer_aid, single_layer_tid);
+                    pdev->windows[single_layer_tid] = create_window(pdev->display, pdev->use_subsurface, single_layer_aid, single_layer_tid, {0, 0, 0, 255});
                     property_set("waydroid.open_windows", std::to_string(pdev->windows.size()).c_str());
                 }
                 window = pdev->windows[single_layer_tid];
@@ -571,7 +571,7 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
 
                 if (showWindow) {
                     if (pdev->windows.find(layer_tid) == pdev->windows.end()) {
-                        pdev->windows[layer_tid] = create_window(pdev->display, pdev->use_subsurface, layer_aid, layer_tid);
+                        pdev->windows[layer_tid] = create_window(pdev->display, pdev->use_subsurface, layer_aid, layer_tid, {0, 0, 0, 0});
                         property_set("waydroid.open_windows", std::to_string(pdev->windows.size()).c_str());
                     }
                     if (pdev->windows.find(layer_tid) != pdev->windows.end())
@@ -626,7 +626,7 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
             }
             if (LayerRawName == "InputMethod") {
                 if (pdev->windows.find(LayerRawName) == pdev->windows.end()) {
-                    pdev->windows[LayerRawName] = create_window(pdev->display, pdev->use_subsurface, LayerRawName, "none");
+                    pdev->windows[LayerRawName] = create_window(pdev->display, pdev->use_subsurface, LayerRawName, "none", {0, 0, 0, 0});
                     property_set("waydroid.open_windows", std::to_string(pdev->windows.size()).c_str());
                 }
                 if (pdev->windows.find(LayerRawName) != pdev->windows.end())
@@ -990,7 +990,7 @@ static int hwc_open(const struct hw_module_t* module, const char* name,
     pdev->display->waiting_for_data = false;
     pdev->vsync_callback_enabled = true;
     pthread_mutex_lock(&pdev->display->data_mutex);
-    pdev->calib_window = create_window(pdev->display, false, "Waydroid", "0");
+    pdev->calib_window = create_window(pdev->display, false, "Waydroid", "0", {});
     if (!property_get_bool("persist.waydroid.cursor_on_subsurface", false))
         pdev->display->cursor_surface =
             wl_compositor_create_surface(pdev->display->compositor);

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -410,6 +410,8 @@ destroy_window(struct window *window, bool keep)
             wl_shell_surface_destroy(window->shell_surface);
         if (window->viewport)
             wp_viewport_destroy(window->viewport);
+        if (window->buffer)
+            wl_buffer_destroy(window->buffer);
 
         wl_surface_destroy(window->surface);
     }
@@ -432,6 +434,7 @@ create_window(struct display *display, bool with_dummy, std::string appID, std::
     window->taskID = taskID;
     window->isActive = true;
     window->viewport = NULL;
+    window->buffer = NULL;
 
     if (display->wm_base) {
         window->xdg_surface =
@@ -499,10 +502,10 @@ create_window(struct display *display, bool with_dummy, std::string appID, std::
         *buf = color.a << 24 | color.r << 16 | color.g << 8 | color.b;
 
         struct wl_shm_pool *pool = wl_shm_create_pool(display->shm, fd, 4);
-        struct wl_buffer *buffer_shm = wl_shm_pool_create_buffer(pool, 0, 1, 1, 4, WL_SHM_FORMAT_ARGB8888);
+        window->buffer = wl_shm_pool_create_buffer(pool, 0, 1, 1, 4, WL_SHM_FORMAT_ARGB8888);
         wl_shm_pool_destroy(pool);
         close(fd);
-        wl_surface_attach(window->surface, buffer_shm, 0, 0);
+        wl_surface_attach(window->surface, window->buffer, 0, 0);
         wl_surface_damage_buffer(window->surface, 0, 0, 1, 1);
 
         if (display->isWinResSet) {

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -61,6 +61,7 @@
 #include <wayland-client.h>
 #include <wayland-android-client-protocol.h>
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
+#include "viewporter-client-protocol.h"
 #include "presentation-time-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 #include "tablet-unstable-v2-client-protocol.h"
@@ -1552,6 +1553,9 @@ registry_handle_global(void *data, struct wl_registry *registry,
             wp_presentation_add_listener(d->presentation,
                     &presentation_listener, d);
         }
+    } else if (strcmp(interface, "wp_viewporter") == 0) {
+        d->viewporter = (struct wp_viewporter*)wl_registry_bind(registry, id,
+                &wp_viewporter_interface, 1);
     } else if ((d->gtype == GRALLOC_ANDROID) &&
                (strcmp(interface, "android_wlegl") == 0)) {
         d->android_wlegl = (struct android_wlegl*)wl_registry_bind(registry, id,

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -513,6 +513,16 @@ create_window(struct display *display, bool with_dummy, std::string appID, std::
             wp_viewport_set_source(window->viewport, wl_fixed_from_int(0), wl_fixed_from_int(0), wl_fixed_from_int(1), wl_fixed_from_int(1));
             wp_viewport_set_destination(window->viewport, display->width / display->scale, display->height / display->scale);
         }
+
+        struct wl_region *region = wl_compositor_create_region(display->compositor);
+        if (color.a == 0) {
+            wl_surface_set_input_region(window->surface, region);
+        }
+        if (color.a == 255) {
+            wl_region_add(region, 0, 0, display->width / display->scale, display->height / display->scale);
+            wl_surface_set_opaque_region(window->surface, region);
+        }
+        wl_region_destroy(region);
     }
     return window;
 }

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -45,6 +45,7 @@
 #include <map>
 #include <list>
 #include <pthread.h>
+#include <hardware/hwcomposer.h>
 #include <vendor/waydroid/task/1.0/IWaydroidTask.h>
 
 using ::android::sp;
@@ -163,6 +164,7 @@ struct window {
     struct wl_shell_surface *shell_surface;
     struct xdg_surface *xdg_surface;
     struct xdg_toplevel *xdg_toplevel;
+    struct wp_viewport *viewport;
     std::map<size_t, struct wl_surface *> surfaces;
     std::map<size_t, struct wl_subsurface *> subsurfaces;
     struct wl_callback *callback;
@@ -193,4 +195,4 @@ destroy_display(struct display *display);
 void
 destroy_window(struct window *window, bool keep = false);
 struct window *
-create_window(struct display *display, bool with_dummy, std::string appID, std::string taskID);
+create_window(struct display *display, bool with_dummy, std::string appID, std::string taskID, hwc_color_t color);

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -96,6 +96,7 @@ struct display {
     struct wl_touch *touch;
     struct wl_output *output;
     struct wp_presentation *presentation;
+    struct wp_viewporter *viewporter;
     struct android_wlegl *android_wlegl;
     struct zwp_linux_dmabuf_v1 *dmabuf;
     struct xdg_wm_base *wm_base;

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -165,6 +165,7 @@ struct window {
     struct xdg_surface *xdg_surface;
     struct xdg_toplevel *xdg_toplevel;
     struct wp_viewport *viewport;
+    struct wl_buffer *buffer;
     std::map<size_t, struct wl_surface *> surfaces;
     std::map<size_t, struct wl_subsurface *> subsurfaces;
     struct wl_callback *callback;


### PR DESCRIPTION
HWC assumes that there's an implicit solid black layer below all the other layers to compose onto. Since we already have a dummy buffer attached to the xdg-toplevel surface, it can be used to provide that background in single window mode, which fixes some apps having transparent background in unexpected places. Thanks to wp_viewporter, the buffer can still be just a single pixel, which gets upscaled to cover the whole window by the compositor.

Since multi window mode relies on the background being transparent, keep it that way there by allowing to specify window background color in create_window.

When the background is transparent, we don't want it to consume any input events.

Similarly, when the background is fully opaque, we know that the whole surface is opaque too, so we can mark it as such to allow the Wayland compositor to optimize its drawing.

Also, don't leak the dummy wl_buffer on window destroy.