### PR TITLE
hwcomposer: Force single window mode during boot animation

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -454,6 +454,15 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
     std::string single_layer_tid;
     std::string single_layer_aid;
 
+    for (size_t l = 0; l < contents->numHwLayers; l++) {
+        std::string layer_name = pdev->display->layer_names[l];
+        if (layer_name.rfind("BootAnimation#", 0) == 0) {
+            // force single window mode during boot animation
+            active_apps = "Waydroid";
+            break;
+        }
+    }
+
     std::scoped_lock lock(pdev->display->windowsMutex);
     if (active_apps == "none") {
         // Clear all open windows

--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -1158,32 +1158,22 @@ static int hwc_open(const struct hw_module_t* module, const char* name,
     }
     ALOGE("wayland display %p", pdev->display);
 
-    struct timespec timeToWait;
-    struct timeval now;
-    gettimeofday(&now, NULL);
-    timeToWait.tv_sec = now.tv_sec + 5;
-    timeToWait.tv_nsec = (now.tv_usec + 1000UL * 2000) * 1000UL;
-
     pthread_mutex_init(&pdev->vsync_lock, NULL);
     pthread_mutex_init(&pdev->display->data_mutex, NULL);
     pthread_cond_init(&pdev->display->data_available_cond, NULL);
     pdev->display->waiting_for_data = false;
     pdev->vsync_callback_enabled = true;
-    pthread_mutex_lock(&pdev->display->data_mutex);
-    pdev->calib_window = create_window(pdev->display, false, "Waydroid", "0", {});
+
+    choose_width_height(pdev->display, 0, 0);
+    pdev->windows["Waydroid"] = create_window(pdev->display, pdev->use_subsurface, "Waydroid", "0", {0, 0, 0, 255});
+    property_set("waydroid.open_windows", "1");
+
+    if (pdev->display->refresh > 1000 && pdev->display->refresh < 1000000)
+        pdev->vsync_period_ns = 1000 * 1000 * 1000 / (pdev->display->refresh / 1000);
+
     if (!property_get_bool("persist.waydroid.cursor_on_subsurface", false))
         pdev->display->cursor_surface =
             wl_compositor_create_surface(pdev->display->compositor);
-    if (!pdev->display->height) {
-        pdev->display->waiting_for_data = true;
-        pthread_cond_timedwait(&pdev->display->data_available_cond,
-                               &pdev->display->data_mutex, &timeToWait);
-        pdev->display->waiting_for_data = false;
-    }
-    destroy_window(pdev->calib_window);
-    pthread_mutex_unlock(&pdev->display->data_mutex);
-    if (pdev->display->refresh > 1000 && pdev->display->refresh < 1000000)
-        pdev->vsync_period_ns = 1000 * 1000 * 1000 / (pdev->display->refresh / 1000);
 
     struct timespec rt;
     if (clock_gettime(CLOCK_MONOTONIC, &rt) == -1) {

--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -454,12 +454,14 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
     std::string single_layer_tid;
     std::string single_layer_aid;
 
-    for (size_t l = 0; l < contents->numHwLayers; l++) {
-        std::string layer_name = pdev->display->layer_names[l];
-        if (layer_name.rfind("BootAnimation#", 0) == 0) {
-            // force single window mode during boot animation
-            active_apps = "Waydroid";
-            break;
+    if (active_apps != "Waydroid" && !property_get_bool("waydroid.background_start", true)) {
+        for (size_t l = 0; l < contents->numHwLayers; l++) {
+            std::string layer_name = pdev->display->layer_names[l];
+            if (layer_name.rfind("BootAnimation#", 0) == 0) {
+                // force single window mode during boot animation
+                active_apps = "Waydroid";
+                break;
+            }
         }
     }
 
@@ -1165,9 +1167,14 @@ static int hwc_open(const struct hw_module_t* module, const char* name,
     pdev->vsync_callback_enabled = true;
 
     choose_width_height(pdev->display, 0, 0);
-    pdev->windows["Waydroid"] = create_window(pdev->display, pdev->use_subsurface, "Waydroid", "0", {0, 0, 0, 255});
-    property_set("waydroid.active_apps", "Waydroid");
-    property_set("waydroid.open_windows", "1");
+    auto first_window = create_window(pdev->display, pdev->use_subsurface, "Waydroid", "0", {0, 0, 0, 255});
+    if (!property_get_bool("waydroid.background_start", true)) {
+        pdev->windows["Waydroid"] = first_window;
+        property_set("waydroid.active_apps", "Waydroid");
+        property_set("waydroid.open_windows", "1");
+    } else {
+        destroy_window(first_window);
+    }
 
     if (pdev->display->refresh > 1000 && pdev->display->refresh < 1000000)
         pdev->vsync_period_ns = 1000 * 1000 * 1000 / (pdev->display->refresh / 1000);

--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -1166,6 +1166,7 @@ static int hwc_open(const struct hw_module_t* module, const char* name,
 
     choose_width_height(pdev->display, 0, 0);
     pdev->windows["Waydroid"] = create_window(pdev->display, pdev->use_subsurface, "Waydroid", "0", {0, 0, 0, 255});
+    property_set("waydroid.active_apps", "Waydroid");
     property_set("waydroid.open_windows", "1");
 
     if (pdev->display->refresh > 1000 && pdev->display->refresh < 1000000)

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -164,7 +164,6 @@ struct display {
     std::map<buffer_handle_t, struct buffer *> buffer_map;
     std::array<uint8_t, 239> keysDown;
 
-    bool isWinResSet;
     bool isMaximized;
     sp<IWaydroidTask> task;
 };
@@ -243,3 +242,5 @@ void
 destroy_window(struct window *window, bool keep = false);
 struct window *
 create_window(struct display *display, bool with_dummy, std::string appID, std::string taskID, hwc_color_t color);
+void
+choose_width_height(struct display* display, int32_t hint_width, int32_t hint_height);


### PR DESCRIPTION
This provides feedback to the user that the Android OS is launching.