### PR TITLE
hwcomposer: Use wl_surface_damage_buffer

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -599,7 +599,7 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
                     }
 
                     wl_surface_attach(pdev->display->cursor_surface, buf->buffer, 0, 0);
-                    wl_surface_damage(pdev->display->cursor_surface, 0, 0, buf->width, buf->height);
+                    wl_surface_damage_buffer(pdev->display->cursor_surface, 0, 0, buf->width, buf->height);
                     if (pdev->display->scale > 1)
                         wl_surface_set_buffer_scale(pdev->display->cursor_surface, pdev->display->scale);
 
@@ -675,7 +675,7 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
         window->lastLayer++;
 
         wl_surface_attach(surface, buf->buffer, 0, 0);
-        wl_surface_damage(surface, 0, 0, buf->width, buf->height);
+        wl_surface_damage_buffer(surface, 0, 0, buf->width, buf->height);
         if (pdev->display->scale > 1)
             wl_surface_set_buffer_scale(surface, pdev->display->scale);
 

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -502,7 +502,7 @@ create_window(struct display *display, bool with_dummy, std::string appID, std::
         wl_shm_pool_destroy(pool);
         close(fd);
         wl_surface_attach(window->surface, buffer_shm, 0, 0);
-        wl_surface_damage(window->surface, 0, 0, 1, 1);
+        wl_surface_damage_buffer(window->surface, 0, 0, 1, 1);
     }
     return window;
 }


### PR DESCRIPTION
wl_surface_damage uses surface coordinates, so the current usage was wrong on scaled displays. Also, wl_surface_damage is deprecated in favor of wl_surface_damage_buffer, which uses buffer coordinates, so let's just use it.