### PR TITLE
hwcomposer: Switch focused task on keyboard focus instead of ACTIVATED state

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -201,6 +201,7 @@ static struct wl_surface *get_surface(struct waydroid_hwc_composer_device_1 *pde
         pdev->display->layers[window->surface] = {
             .x = layer->displayFrame.left,
             .y = layer->displayFrame.top };
+        pdev->display->windows[window->surface] = window;
         return window->surface;
     }
 
@@ -229,6 +230,7 @@ static struct wl_surface *get_surface(struct waydroid_hwc_composer_device_1 *pde
     pdev->display->layers[window->surfaces[window->lastLayer]] = {
         .x = layer->displayFrame.left,
         .y = layer->displayFrame.top };
+    pdev->display->windows[window->surfaces[window->lastLayer]] = window;
     return window->surfaces[window->lastLayer];
 }
 

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -289,7 +289,7 @@ static const struct xdg_surface_listener xdg_surface_listener = {
 static void
 xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *,
                               int32_t width, int32_t height,
-                              struct wl_array *states)
+                              struct wl_array *)
 {
     struct window *window = (struct window *)data;
 
@@ -308,22 +308,6 @@ xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *,
         window->display->isWinResSet = true;
         if (window->display->waiting_for_data)
             pthread_cond_broadcast(&window->display->data_available_cond);
-    }
-
-    for (enum xdg_toplevel_state *state = static_cast<xdg_toplevel_state *>(states->data);
-         reinterpret_cast<uint8_t *>(state) < (static_cast<uint8_t *>(states->data) + states->size);
-         state++) {
-        switch (*state) {
-            case XDG_TOPLEVEL_STATE_ACTIVATED:
-                if (window->display->task != nullptr) {
-                    if (window->taskID != "none" && window->taskID != "0") {
-                            window->display->task->setFocusedTask(stoi(window->taskID));
-                    }
-                }
-                break;
-            default:
-                break;
-        }
     }
 }
 
@@ -565,10 +549,22 @@ keyboard_handle_keymap(void *, struct wl_keyboard *,
 }
 
 static void
-keyboard_handle_enter(void *, struct wl_keyboard *,
-                      uint32_t, struct wl_surface *,
+keyboard_handle_enter(void *data, struct wl_keyboard *,
+                      uint32_t, struct wl_surface *surface,
                       struct wl_array *)
 {
+    struct display *display = (struct display *)data;
+
+    if (display->windows.find(surface) == display->windows.end())
+        return;
+
+    struct window *window = display->windows[surface];
+
+    if (window->display->task != nullptr) {
+        if (window->taskID != "none" && window->taskID != "0") {
+            window->display->task->setFocusedTask(stoi(window->taskID));
+        }
+    }
 }
 
 static void

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -83,6 +83,8 @@ struct handleExt {
     uint32_t stride;
 };
 
+struct window;
+
 struct display {
     struct wl_display *display;
     struct wl_registry *registry;
@@ -116,6 +118,7 @@ struct display {
     bool reverseScroll;
     int touch_id[MAX_TOUCHPOINTS];
     std::map<struct wl_surface *, struct layerFrame> layers;
+    std::map<struct wl_surface *, struct window *> windows;
     std::map<int, struct wl_surface *> touch_surfaces;
     struct wl_surface *pointer_surface;
     struct wl_surface *cursor_surface;


### PR DESCRIPTION
XDG_TOPLEVEL_STATE_ACTIVATED cannot be used to track focus. It's only meant to provide visual clues, and some compositors may decide to make windows appear activated even if they're not focused (for example, to make them look better in expose mode or activity switchers). Use keyboard focus instead.

Marked as draft because I haven't had a chance to test it with regular desktopy compositor yet and where I did test it I have issues with focus regardless of this patch's presence - so some external testing will be appreciated.