### PR TITLE
hwcomposer: Fix explicit sync and use it with subsurfaces too

### DIFF
--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -75,8 +75,8 @@ buffer_release(void *data, struct wl_buffer *)
     struct buffer *mybuf = (struct buffer*)data;
 
     sw_sync_timeline_inc(mybuf->timeline_fd, 1);
-    close(mybuf->release_fence_fd);
-    mybuf->release_fence_fd = -1;
+    close(mybuf->timeline_fd);
+    mybuf->timeline_fd = -1;
 }
 
 static const struct wl_buffer_listener buffer_listener = {

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -152,7 +152,6 @@ struct buffer {
     int format;
 
     int timeline_fd;
-    int release_fence_fd;
     bool isShm;
     void *shm_data;
 };


### PR DESCRIPTION
Release fences can't use a shared timeline, because they're unrelated events that can happen out of order.

Also, move retire fence creation at the end of hwc_set, so its descriptor doesn't have to be closed on every early return, and make the retire fence actually be signalled when commiting the next composition on Wayland surface.