### PR TITLE
hwcomposer: Implement cropping, scaling and transforms

### DIFF
--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -399,6 +399,7 @@ destroy_window(struct window *window, bool keep)
             wl_callback_destroy(window->callback);
 
         for (auto it = window->surfaces.begin(); it != window->surfaces.end(); it++) {
+            wp_viewport_destroy(window->viewports[it->first]);
             wl_subsurface_destroy(window->subsurfaces[it->first]);
             wl_surface_destroy(it->second);
         }

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -61,6 +61,7 @@
 #include <wayland-client.h>
 #include <wayland-android-client-protocol.h>
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
+#include "viewporter-client-protocol.h"
 #include "presentation-time-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 #include "tablet-unstable-v2-client-protocol.h"
@@ -1552,6 +1553,9 @@ registry_handle_global(void *data, struct wl_registry *registry,
             wp_presentation_add_listener(d->presentation,
                     &presentation_listener, d);
         }
+    } else if (strcmp(interface, "wp_viewporter") == 0) {
+        d->viewporter = (struct wp_viewporter*)wl_registry_bind(registry, id,
+                &wp_viewporter_interface, 1);
     } else if ((d->gtype == GRALLOC_ANDROID) &&
                (strcmp(interface, "android_wlegl") == 0)) {
         d->android_wlegl = (struct android_wlegl*)wl_registry_bind(registry, id,

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -165,6 +165,7 @@ struct window {
     struct xdg_toplevel *xdg_toplevel;
     std::map<size_t, struct wl_surface *> surfaces;
     std::map<size_t, struct wl_subsurface *> subsurfaces;
+    std::map<size_t, struct wp_viewport *> viewports;
     struct wl_callback *callback;
     int lastLayer;
     std::string taskID;

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -96,6 +96,7 @@ struct display {
     struct wl_touch *touch;
     struct wl_output *output;
     struct wp_presentation *presentation;
+    struct wp_viewporter *viewporter;
     struct android_wlegl *android_wlegl;
     struct zwp_linux_dmabuf_v1 *dmabuf;
     struct xdg_wm_base *wm_base;


### PR DESCRIPTION
HWC is expected to handle buffer cropping (sourceCrop) and destination scaling (displayFrame). This is implemented with Wayland surfaces via wp_viewporter, fixing many issues with popup placement, background handling etc.

HWC is also supposed to handle layer rotation, which is used to implement screen rotation. Wayland has a concept of buffer transform, so use that to fix screen rotation handling with subsurfaces.