### PR TITLE
hwcomposer: Flush Wayland display after destroying a window

### DIFF
--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -415,6 +415,7 @@ destroy_window(struct window *window, bool keep)
             wl_buffer_destroy(window->buffer);
 
         wl_surface_destroy(window->surface);
+        wl_display_flush(window->display->display);
     }
     if (keep)
         window->isActive = false;


### PR DESCRIPTION
Otherwise the window may stay on screen until user takes some action that generates Wayland events.