### PR TITLE
hwcomposer: Simulate a key press on window close

### DIFF
--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -313,9 +313,16 @@ xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *,
 }
 
 static void
+send_key_event(display *data, uint32_t key, wl_keyboard_key_state state);
+
+static void
 xdg_toplevel_handle_close(void *data, struct xdg_toplevel *)
 {
     struct window *window = (struct window *)data;
+
+    // simulate user input to restart idle timeout (TODO: find a better way)
+    send_key_event(window->display, 0, WL_KEYBOARD_KEY_STATE_PRESSED);
+    send_key_event(window->display, 0, WL_KEYBOARD_KEY_STATE_RELEASED);
 
     if (window->display->task != nullptr) {
         if (window->taskID != "none") {


### PR DESCRIPTION
This is meant to restart the idle timer, so suspending can work even after closing the window with idle timeout already passed.
See https://github.com/waydroid/waydroid/issues/500

Initially I wanted to use pointer movement, but that doesn't work when there's no pointer (which, well, is not unusual on a phone).

Is there a better way to restart idle timers? Maybe something like taking screen wakelock and releasing it immediately? I don't know much about Android, so for now I have simply used something that was already at hand ;)