### PR TITLE
hide gralloc.gbm when mesa is not built

### DIFF
--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -20,6 +20,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
+ifneq ($(TARGET_USE_MESA),false)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := \
@@ -42,6 +43,7 @@ LOCAL_MODULE_RELATIVE_PATH := hw
 LOCAL_PROPRIETARY_MODULE := true
 
 include $(BUILD_SHARED_LIBRARY)
+endif
 
 include $(CLEAR_VARS)
 


### PR DESCRIPTION
for TARGET_USE_MESA=false builds

along with https://github.com/waydroid/android_external_minigbm/pull/1