### PR TITLE
health_service: Disable periodic chores

### DIFF
--- a/health/health_service.cpp
+++ b/health/health_service.cpp
@@ -24,7 +24,10 @@
 using android::hardware::health::V2_0::DiskStats;
 using android::hardware::health::V2_0::StorageInfo;
 
-void healthd_board_init(struct healthd_config*) {}
+void healthd_board_init(struct healthd_config* config) {
+  config->periodic_chores_interval_fast = -1;
+  config->periodic_chores_interval_slow = -1;
+}
 
 int healthd_board_battery_update(
     struct android::BatteryProperties* battery_props) {


### PR DESCRIPTION
Fake battery status doesn't change, so there's nothing for healthd   to check periodically. Since healthd is using CLOCK_BOOTTIME_ALARM timers, this was causing the host to wake up from suspend very  often (the default timeout in effect was 60 seconds).

Fixes https://github.com/waydroid/waydroid/issues/168

**NOTE**: I haven't tested this. If you want to save me from having to spin up another Android image build, feel free to test it - I'll be grateful:)