### PR TITLE
Fix for issue playing YouTube videos through the built-in Chromium browser

### DIFF
--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -502,28 +502,6 @@ static int out_get_render_position(const struct audio_stream_out *stream,
     return -EINVAL;
 }
 
-static int out_get_presentation_position(const struct audio_stream_out *stream,
-                                   uint64_t *frames, struct timespec *timestamp)
-{
-    struct alsa_stream_out *out = (struct alsa_stream_out *)stream;
-    int ret = -ENODATA;
-
-        if (out->pcm) {
-            snd_pcm_uframes_t avail;
-            if (snd_pcm_htimestamp(out->pcm, &avail, timestamp) == 0) {
-                size_t kernel_buffer_size = out->config.period_size * out->config.period_count;
-                int64_t signed_frames = out->written - kernel_buffer_size + avail;
-                if (signed_frames >= 0) {
-                    *frames = signed_frames;
-                    ret = 0;
-                }
-            }
-        }
-
-    return ret;
-}
-
-
 static int out_add_audio_effect(const struct audio_stream *stream, effect_handle_t effect)
 {
     ALOGV("out_add_audio_effect: %p", effect);
@@ -836,7 +814,6 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
     out->stream.write = out_write;
     out->stream.get_render_position = out_get_render_position;
     out->stream.get_next_write_timestamp = out_get_next_write_timestamp;
-    out->stream.get_presentation_position = out_get_presentation_position;
 
     out->config.channels = CHANNEL_STEREO;
     out->config.rate = PLAYBACK_CODEC_SAMPLING_RATE;


### PR DESCRIPTION
The problem is described in more detail here: https://github.com/waydroid/waydroid/discussions/855. 

It was found that when using pulse PCM, snd_pcm_htimestamp returns correct data, judging by the description:

out_get_presentation_position: ret = 0 , frames = 1165312, ts=1711351920.591045044

But at the same time the playback of the video stops on the initial frame, and the sound is looped on the playback of the first 10 seconds. In other players there are no problems, personally I have Fennec on arm64 played video correctly, although in the discussion other users complained about errors on x64_86, players like NewPipe and VLC had no problems.

If I changed PCM to hardware PCM (having previously thrown it into the container), the video started playing correctly with sound. However, snd_pcm_htimestamp returned zero timestamp in this case:

audio_hw_primary: out_get_presentation_position: ret = 0 , frames = 1478708, ts=0.000000000

Also, replacing audio.primary.waydroid.so with the default null library returned correct playback
Therefore, the simplest solution is to remove the out_get_presentation_position callback.

As far as I could check, this solution has no side effects; all the programs I tested played video and sound correctly. And this is easier than finding the reason for the incorrect operation of chromium or searching for the peculiarities of how snd_pcm_htimestamp works in a container and without it.