### PR TITLE
hwcomposer: wp_cursor_shape_manager_v1 implements

### DIFF
--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -73,6 +73,7 @@
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "cursor-shape-v1-client-protocol.h"
 
 using ::android::hardware::hidl_string;
 
@@ -816,9 +817,17 @@ pointer_handle_enter(void *data, struct wl_pointer *pointer,
 {
     struct display *display = (struct display *)data;
     display->pointer_surface = surface;
-    if (display->cursor_surface)
-        wl_pointer_set_cursor(pointer, serial,
-                              display->cursor_surface, 0, 0);
+    if (display->cursor_shape_manager != NULL) {
+        struct wp_cursor_shape_device_v1 *device =
+            wp_cursor_shape_manager_v1_get_pointer(display->cursor_shape_manager, pointer);
+        wp_cursor_shape_device_v1_set_shape(device, serial,
+            WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT);
+        wp_cursor_shape_device_v1_destroy(device);
+    } else {
+        if (display->cursor_surface)
+            wl_pointer_set_cursor(pointer, serial,
+                                  display->cursor_surface, 0, 0); // FIXME: cursor hotspot with scale
+    }
 }
 
 static void
@@ -1828,6 +1837,9 @@ registry_handle_global(void *data, struct wl_registry *registry,
                 &wl_output_interface, std::min(version, 3U));
         wl_output_add_listener(d->output, &output_listener, d);
         wl_display_roundtrip(d->display);
+    } else if (strcmp(interface, "wp_cursor_shape_manager_v1") == 0) {
+        d->cursor_shape_manager = (struct wp_cursor_shape_manager_v1*)wl_registry_bind(registry, id,
+                &wp_cursor_shape_manager_v1_interface, 1);
     } else if (strcmp(interface, "wp_presentation") == 0) {
         bool no_presentation = property_get_bool("persist.waydroid.no_presentation", false);
         if (!no_presentation) {

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -121,6 +121,7 @@ struct display {
     struct zwp_relative_pointer_v1 *relative_pointer;
     struct zwp_idle_inhibit_manager_v1 *idle_manager;
     struct wp_fractional_scale_manager_v1 *fractional_scale_manager;
+    struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
     struct wl_data_device_manager *data_device_manager;
     struct wl_data_device *data_device;
 


### PR DESCRIPTION
protocol [android_vendor_waydroid/pull/37](https://github.com/waydroid/android_vendor_waydroid/pull/37) requires

This fix invisible cursor if that window focus switch from playing fullscreen video out of waydroid