### PR TITLE
hwcomposer: Blacklist com.google.android.tvlauncher for ATV

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -727,6 +727,8 @@ static int hwc_open(const struct hw_module_t* module, const char* name,
 
     pdev->blacklisted_apps["com.android.launcher3"] = {};
     pdev->blacklisted_apps["com.android.settings"] = {"com.android.settings.FallbackHome"};
+    pdev->blacklisted_apps["com.android.tv.settings"] = {"com.android.tv.settings.system.FallbackHome"};
+    pdev->blacklisted_apps["com.google.android.tvlauncher"] = {};
     if (property_get("waydroid.blacklist_apps", property, nullptr) > 0) {
         std::string blacklist_apps = std::string(property);
         std::istringstream iss(blacklist_apps);


### PR DESCRIPTION
This fixes https://github.com/supechicken/waydroid-androidtv-build/issues/62

> I launch the desired apps via KDE Plasma using its panel and that works wonderfully... but doing so also opens the Android TV Home screen in another Waydroid window at the same time. Closing the desired app goes back to the Android TV Home screen every time, and trying to close the Android TV Home screen with Alt + F4 (as I do with apps) just immediately re-opens the Home screen.