### PR TITLE
vulkan: add ETC2/EAC format compatibility layer for Intel GPUs

### DIFF
--- a/vulkan/Android.bp
+++ b/vulkan/Android.bp
@@ -20,6 +20,9 @@ cc_library_shared {
     header_libs: [
         "vulkan_headers",
     ],
+    shared_libs: [
+        "liblog",
+    ],
     cflags: [
         "-DLOG_TAG=\"VkLayer_waydroid_compat\"",
         "-Wall",

--- a/vulkan/Android.bp
+++ b/vulkan/Android.bp
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 The Waydroid Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cc_library_shared {
+    name: "VkLayer_waydroid_compat",
+    vendor: true,
+    relative_install_path: "vulkan",
+    srcs: ["VkLayer_waydroid_compat.c"],
+    header_libs: [
+        "vulkan_headers",
+    ],
+    cflags: [
+        "-DLOG_TAG=\"VkLayer_waydroid_compat\"",
+        "-Wall",
+        "-Werror",
+        "-fvisibility=hidden",
+    ],
+    ldflags: ["-Wl,--no-undefined"],
+}
+
+// Install the layer manifest JSON to vendor/etc/vulkan/implicit_layer.d/
+prebuilt_etc {
+    name: "VkLayer_waydroid_compat.json",
+    vendor: true,
+    sub_dir: "vulkan/implicit_layer.d",
+    src: "VkLayer_waydroid_compat.json",
+}

--- a/vulkan/Android.bp
+++ b/vulkan/Android.bp
@@ -27,6 +27,7 @@ cc_library_shared {
         "-fvisibility=hidden",
     ],
     ldflags: ["-Wl,--no-undefined"],
+    init_rc: ["init.vulkan.waydroid.rc"],
 }
 
 // Install the layer manifest JSON to vendor/etc/vulkan/implicit_layer.d/

--- a/vulkan/VkLayer_waydroid_compat.c
+++ b/vulkan/VkLayer_waydroid_compat.c
@@ -26,6 +26,9 @@
  * This layer intercepts vkGetPhysicalDeviceFormatProperties{,2} and
  * reports zero feature flags for all ETC2/EAC formats, causing apps
  * to fall back to uncompressed textures.
+ *
+ * Note: uses a single global dispatch table. This is safe for Waydroid
+ * since it only ever creates a single Vulkan instance per container.
  */
 
 #include <string.h>
@@ -33,7 +36,6 @@
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
 
-/* Dispatch table, single-instance (Waydroid only creates one) */
 typedef struct {
     PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
     PFN_vkDestroyInstance DestroyInstance;
@@ -64,7 +66,29 @@ static int is_etc2_eac_format(VkFormat format)
     }
 }
 
-/* Intercepted: zero out features for ETC2/EAC formats */
+static void zero_format_features(VkFormatProperties *props)
+{
+    props->linearTilingFeatures = 0;
+    props->optimalTilingFeatures = 0;
+    props->bufferFeatures = 0;
+}
+
+/* Walk the pNext chain and zero out VkFormatProperties3 if present */
+static void zero_format_features3(VkFormatProperties2 *pFormatProperties)
+{
+    VkBaseOutStructure *ext = (VkBaseOutStructure *)pFormatProperties->pNext;
+    while (ext) {
+        if (ext->sType == VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3) {
+            VkFormatProperties3 *props3 = (VkFormatProperties3 *)ext;
+            props3->linearTilingFeatures = 0;
+            props3->optimalTilingFeatures = 0;
+            props3->bufferFeatures = 0;
+            break;
+        }
+        ext = ext->pNext;
+    }
+}
+
 static VKAPI_ATTR void VKAPI_CALL
 compat_GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice,
                                          VkFormat format,
@@ -72,11 +96,8 @@ compat_GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice,
 {
     g_dispatch.GetPhysicalDeviceFormatProperties(physicalDevice, format,
                                                  pFormatProperties);
-    if (is_etc2_eac_format(format)) {
-        pFormatProperties->linearTilingFeatures = 0;
-        pFormatProperties->optimalTilingFeatures = 0;
-        pFormatProperties->bufferFeatures = 0;
-    }
+    if (is_etc2_eac_format(format))
+        zero_format_features(pFormatProperties);
 }
 
 static VKAPI_ATTR void VKAPI_CALL
@@ -87,9 +108,8 @@ compat_GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice,
     g_dispatch.GetPhysicalDeviceFormatProperties2(physicalDevice, format,
                                                   pFormatProperties);
     if (is_etc2_eac_format(format)) {
-        pFormatProperties->formatProperties.linearTilingFeatures = 0;
-        pFormatProperties->formatProperties.optimalTilingFeatures = 0;
-        pFormatProperties->formatProperties.bufferFeatures = 0;
+        zero_format_features(&pFormatProperties->formatProperties);
+        zero_format_features3(pFormatProperties);
     }
 }
 

--- a/vulkan/VkLayer_waydroid_compat.c
+++ b/vulkan/VkLayer_waydroid_compat.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2026 The Waydroid Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Vulkan implicit layer that masks ETC2/EAC format support to prevent
+ * crashes on Intel GPUs when ARM64 apps use AHardwareBuffer with
+ * compressed textures.
+ *
+ * Mesa ANV does not handle AHardwareBuffer with ETC2 formats through
+ * gralloc, causing a SIGABRT in AHardwareBuffer_getNativeHandle when
+ * gralloc encounters unsupported format 0x38 (ETC2_RGB8).
+ *
+ * This layer intercepts vkGetPhysicalDeviceFormatProperties{,2} and
+ * reports zero feature flags for all ETC2/EAC formats, causing apps
+ * to fall back to uncompressed textures.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <vulkan/vulkan.h>
+#include <vulkan/vk_layer.h>
+
+/* Dispatch table, single-instance (Waydroid only creates one) */
+typedef struct {
+    PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
+    PFN_vkDestroyInstance DestroyInstance;
+    PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
+    PFN_vkGetPhysicalDeviceFormatProperties GetPhysicalDeviceFormatProperties;
+    PFN_vkGetPhysicalDeviceFormatProperties2 GetPhysicalDeviceFormatProperties2;
+    PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
+} InstanceDispatch;
+
+static InstanceDispatch g_dispatch;
+
+static int is_etc2_eac_format(VkFormat format)
+{
+    switch (format) {
+    case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
+    case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
+    case VK_FORMAT_EAC_R11_UNORM_BLOCK:
+    case VK_FORMAT_EAC_R11_SNORM_BLOCK:
+    case VK_FORMAT_EAC_R11G11_UNORM_BLOCK:
+    case VK_FORMAT_EAC_R11G11_SNORM_BLOCK:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* Intercepted: zero out features for ETC2/EAC formats */
+static VKAPI_ATTR void VKAPI_CALL
+compat_GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice,
+                                         VkFormat format,
+                                         VkFormatProperties *pFormatProperties)
+{
+    g_dispatch.GetPhysicalDeviceFormatProperties(physicalDevice, format,
+                                                 pFormatProperties);
+    if (is_etc2_eac_format(format)) {
+        pFormatProperties->linearTilingFeatures = 0;
+        pFormatProperties->optimalTilingFeatures = 0;
+        pFormatProperties->bufferFeatures = 0;
+    }
+}
+
+static VKAPI_ATTR void VKAPI_CALL
+compat_GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice,
+                                          VkFormat format,
+                                          VkFormatProperties2 *pFormatProperties)
+{
+    g_dispatch.GetPhysicalDeviceFormatProperties2(physicalDevice, format,
+                                                  pFormatProperties);
+    if (is_etc2_eac_format(format)) {
+        pFormatProperties->formatProperties.linearTilingFeatures = 0;
+        pFormatProperties->formatProperties.optimalTilingFeatures = 0;
+        pFormatProperties->formatProperties.bufferFeatures = 0;
+    }
+}
+
+/* Instance creation: set up dispatch chain */
+static VKAPI_ATTR VkResult VKAPI_CALL
+compat_CreateInstance(const VkInstanceCreateInfo *pCreateInfo,
+                     const VkAllocationCallbacks *pAllocator,
+                     VkInstance *pInstance)
+{
+    VkLayerInstanceCreateInfo *layer_info =
+            (VkLayerInstanceCreateInfo *)pCreateInfo->pNext;
+
+    while (layer_info &&
+           (layer_info->sType !=
+                    VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO ||
+            layer_info->function != VK_LAYER_LINK_INFO)) {
+        layer_info = (VkLayerInstanceCreateInfo *)layer_info->pNext;
+    }
+
+    if (!layer_info)
+        return VK_ERROR_INITIALIZATION_FAILED;
+
+    PFN_vkGetInstanceProcAddr next_gipa =
+            layer_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
+
+    /* Advance the chain for the next layer */
+    layer_info->u.pLayerInfo = layer_info->u.pLayerInfo->pNext;
+
+    PFN_vkCreateInstance create_instance =
+            (PFN_vkCreateInstance)next_gipa(VK_NULL_HANDLE, "vkCreateInstance");
+    if (!create_instance)
+        return VK_ERROR_INITIALIZATION_FAILED;
+
+    VkResult result = create_instance(pCreateInfo, pAllocator, pInstance);
+    if (result != VK_SUCCESS)
+        return result;
+
+    g_dispatch.GetInstanceProcAddr = next_gipa;
+    g_dispatch.DestroyInstance =
+            (PFN_vkDestroyInstance)next_gipa(*pInstance, "vkDestroyInstance");
+    g_dispatch.EnumeratePhysicalDevices =
+            (PFN_vkEnumeratePhysicalDevices)next_gipa(
+                    *pInstance, "vkEnumeratePhysicalDevices");
+    g_dispatch.GetPhysicalDeviceFormatProperties =
+            (PFN_vkGetPhysicalDeviceFormatProperties)next_gipa(
+                    *pInstance, "vkGetPhysicalDeviceFormatProperties");
+    g_dispatch.GetPhysicalDeviceFormatProperties2 =
+            (PFN_vkGetPhysicalDeviceFormatProperties2)next_gipa(
+                    *pInstance, "vkGetPhysicalDeviceFormatProperties2");
+    g_dispatch.EnumerateDeviceExtensionProperties =
+            (PFN_vkEnumerateDeviceExtensionProperties)next_gipa(
+                    *pInstance, "vkEnumerateDeviceExtensionProperties");
+
+    return VK_SUCCESS;
+}
+
+static VKAPI_ATTR void VKAPI_CALL
+compat_DestroyInstance(VkInstance instance,
+                      const VkAllocationCallbacks *pAllocator)
+{
+    if (g_dispatch.DestroyInstance)
+        g_dispatch.DestroyInstance(instance, pAllocator);
+    memset(&g_dispatch, 0, sizeof(g_dispatch));
+}
+
+__attribute__((visibility("default"))) VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
+compat_GetInstanceProcAddr(VkInstance instance, const char *pName)
+{
+    if (strcmp(pName, "vkCreateInstance") == 0)
+        return (PFN_vkVoidFunction)compat_CreateInstance;
+    if (strcmp(pName, "vkDestroyInstance") == 0)
+        return (PFN_vkVoidFunction)compat_DestroyInstance;
+    if (strcmp(pName, "vkGetPhysicalDeviceFormatProperties") == 0)
+        return (PFN_vkVoidFunction)compat_GetPhysicalDeviceFormatProperties;
+    if (strcmp(pName, "vkGetPhysicalDeviceFormatProperties2") == 0)
+        return (PFN_vkVoidFunction)compat_GetPhysicalDeviceFormatProperties2;
+    if (strcmp(pName, "vkGetPhysicalDeviceFormatProperties2KHR") == 0)
+        return (PFN_vkVoidFunction)compat_GetPhysicalDeviceFormatProperties2;
+
+    if (g_dispatch.GetInstanceProcAddr)
+        return g_dispatch.GetInstanceProcAddr(instance, pName);
+    return NULL;
+}
+
+static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
+compat_GetDeviceProcAddr(VkDevice device, const char *pName)
+{
+    (void)device;
+    (void)pName;
+    return NULL;
+}
+
+/* Layer negotiation (loader interface version 2) */
+__attribute__((visibility("default"))) VKAPI_ATTR VkResult VKAPI_CALL
+vkNegotiateLoaderLayerInterfaceVersion(
+        VkNegotiateLayerInterface *pVersionStruct)
+{
+    if (!pVersionStruct ||
+        pVersionStruct->sType != LAYER_NEGOTIATE_INTERFACE_STRUCT)
+        return VK_ERROR_INITIALIZATION_FAILED;
+
+    if (pVersionStruct->loaderLayerInterfaceVersion >=
+        CURRENT_LOADER_LAYER_INTERFACE_VERSION) {
+        pVersionStruct->loaderLayerInterfaceVersion =
+                CURRENT_LOADER_LAYER_INTERFACE_VERSION;
+    }
+
+    pVersionStruct->pfnGetInstanceProcAddr = compat_GetInstanceProcAddr;
+    pVersionStruct->pfnGetDeviceProcAddr = compat_GetDeviceProcAddr;
+    pVersionStruct->pfnGetPhysicalDeviceProcAddr = NULL;
+
+    return VK_SUCCESS;
+}
+
+static const VkLayerProperties layer_props = {
+        .layerName = "VK_LAYER_WAYDROID_compat",
+        .specVersion = VK_MAKE_VERSION(1, 3, 0),
+        .implementationVersion = 1,
+        .description = "Waydroid ETC2/EAC format compatibility layer",
+};
+
+__attribute__((visibility("default"))) VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceLayerProperties(uint32_t *pPropertyCount,
+                                   VkLayerProperties *pProperties)
+{
+    if (!pProperties) {
+        *pPropertyCount = 1;
+        return VK_SUCCESS;
+    }
+    if (*pPropertyCount < 1)
+        return VK_INCOMPLETE;
+
+    *pPropertyCount = 1;
+    memcpy(pProperties, &layer_props, sizeof(layer_props));
+    return VK_SUCCESS;
+}
+
+__attribute__((visibility("default"))) VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceExtensionProperties(const char *pLayerName,
+                                       uint32_t *pPropertyCount,
+                                       VkExtensionProperties *pProperties)
+{
+    (void)pProperties;
+    if (pLayerName && strcmp(pLayerName, layer_props.layerName) == 0) {
+        *pPropertyCount = 0;
+        return VK_SUCCESS;
+    }
+    return VK_ERROR_LAYER_NOT_PRESENT;
+}

--- a/vulkan/VkLayer_waydroid_compat.c
+++ b/vulkan/VkLayer_waydroid_compat.c
@@ -33,8 +33,17 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <pthread.h>
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#define LOG_TAG "VkLayer_waydroid_compat"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#else
+#define LOGE(...) ((void)0)
+#endif
 
 /* ---- Per-instance dispatch ---- */
 
@@ -52,8 +61,10 @@ typedef struct InstanceDispatchEntry {
 } InstanceDispatchEntry;
 
 static InstanceDispatchEntry *g_instances = NULL;
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 
-static InstanceDispatch *find_instance_dispatch(VkInstance instance)
+/* Caller must hold g_lock */
+static InstanceDispatch *find_instance_dispatch_locked(VkInstance instance)
 {
     InstanceDispatchEntry *entry = g_instances;
     while (entry) {
@@ -71,7 +82,8 @@ static InstanceDispatch *find_instance_dispatch(VkInstance instance)
  * parent instance (the loader guarantees this). We use it to map a
  * VkPhysicalDevice back to the instance dispatch we stored at creation.
  */
-static InstanceDispatch *find_phys_dev_dispatch(VkPhysicalDevice physicalDevice)
+/* Caller must hold g_lock */
+static InstanceDispatch *find_phys_dev_dispatch_locked(VkPhysicalDevice physicalDevice)
 {
     void *key = *(void **)physicalDevice;
     InstanceDispatchEntry *entry = g_instances;
@@ -134,11 +146,19 @@ compat_GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice,
                                          VkFormat format,
                                          VkFormatProperties *pFormatProperties)
 {
-    InstanceDispatch *dispatch = find_phys_dev_dispatch(physicalDevice);
-    if (!dispatch)
+    PFN_vkGetPhysicalDeviceFormatProperties fn = NULL;
+
+    pthread_mutex_lock(&g_lock);
+    InstanceDispatch *dispatch = find_phys_dev_dispatch_locked(physicalDevice);
+    if (dispatch)
+        fn = dispatch->GetPhysicalDeviceFormatProperties;
+    pthread_mutex_unlock(&g_lock);
+
+    if (!fn) {
+        LOGE("dispatch lookup failed for vkGetPhysicalDeviceFormatProperties");
         return;
-    dispatch->GetPhysicalDeviceFormatProperties(physicalDevice, format,
-                                                pFormatProperties);
+    }
+    fn(physicalDevice, format, pFormatProperties);
     if (is_etc2_eac_format(format))
         zero_format_features(pFormatProperties);
 }
@@ -148,11 +168,19 @@ compat_GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice,
                                           VkFormat format,
                                           VkFormatProperties2 *pFormatProperties)
 {
-    InstanceDispatch *dispatch = find_phys_dev_dispatch(physicalDevice);
-    if (!dispatch)
+    PFN_vkGetPhysicalDeviceFormatProperties2 fn = NULL;
+
+    pthread_mutex_lock(&g_lock);
+    InstanceDispatch *dispatch = find_phys_dev_dispatch_locked(physicalDevice);
+    if (dispatch)
+        fn = dispatch->GetPhysicalDeviceFormatProperties2;
+    pthread_mutex_unlock(&g_lock);
+
+    if (!fn) {
+        LOGE("dispatch lookup failed for vkGetPhysicalDeviceFormatProperties2");
         return;
-    dispatch->GetPhysicalDeviceFormatProperties2(physicalDevice, format,
-                                                 pFormatProperties);
+    }
+    fn(physicalDevice, format, pFormatProperties);
     if (is_etc2_eac_format(format)) {
         zero_format_features(&pFormatProperties->formatProperties);
         zero_format_features3(pFormatProperties);
@@ -217,8 +245,10 @@ compat_CreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                     *pInstance, "vkGetPhysicalDeviceFormatProperties2");
 
     /* Prepend to linked list */
+    pthread_mutex_lock(&g_lock);
     entry->next = g_instances;
     g_instances = entry;
+    pthread_mutex_unlock(&g_lock);
 
     return VK_SUCCESS;
 }
@@ -227,20 +257,26 @@ static VKAPI_ATTR void VKAPI_CALL
 compat_DestroyInstance(VkInstance instance,
                       const VkAllocationCallbacks *pAllocator)
 {
+    PFN_vkDestroyInstance destroy_fn = NULL;
+
+    pthread_mutex_lock(&g_lock);
     InstanceDispatchEntry **prev = &g_instances;
     InstanceDispatchEntry *entry = g_instances;
 
     while (entry) {
         if (entry->instance == instance) {
             *prev = entry->next;
-            if (entry->dispatch.DestroyInstance)
-                entry->dispatch.DestroyInstance(instance, pAllocator);
+            destroy_fn = entry->dispatch.DestroyInstance;
             free(entry);
-            return;
+            break;
         }
         prev = &entry->next;
         entry = entry->next;
     }
+    pthread_mutex_unlock(&g_lock);
+
+    if (destroy_fn)
+        destroy_fn(instance, pAllocator);
 }
 
 /* ---- GetInstanceProcAddr ---- */
@@ -259,9 +295,16 @@ compat_GetInstanceProcAddr(VkInstance instance, const char *pName)
     if (strcmp(pName, "vkGetPhysicalDeviceFormatProperties2KHR") == 0)
         return (PFN_vkVoidFunction)compat_GetPhysicalDeviceFormatProperties2;
 
-    InstanceDispatch *dispatch = find_instance_dispatch(instance);
+    PFN_vkGetInstanceProcAddr gipa = NULL;
+
+    pthread_mutex_lock(&g_lock);
+    InstanceDispatch *dispatch = find_instance_dispatch_locked(instance);
     if (dispatch)
-        return dispatch->GetInstanceProcAddr(instance, pName);
+        gipa = dispatch->GetInstanceProcAddr;
+    pthread_mutex_unlock(&g_lock);
+
+    if (gipa)
+        return gipa(instance, pName);
     return NULL;
 }
 

--- a/vulkan/VkLayer_waydroid_compat.c
+++ b/vulkan/VkLayer_waydroid_compat.c
@@ -194,14 +194,6 @@ compat_GetInstanceProcAddr(VkInstance instance, const char *pName)
     return NULL;
 }
 
-static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
-compat_GetDeviceProcAddr(VkDevice device, const char *pName)
-{
-    (void)device;
-    (void)pName;
-    return NULL;
-}
-
 /* Layer negotiation (loader interface version 2) */
 __attribute__((visibility("default"))) VKAPI_ATTR VkResult VKAPI_CALL
 vkNegotiateLoaderLayerInterfaceVersion(
@@ -218,7 +210,7 @@ vkNegotiateLoaderLayerInterfaceVersion(
     }
 
     pVersionStruct->pfnGetInstanceProcAddr = compat_GetInstanceProcAddr;
-    pVersionStruct->pfnGetDeviceProcAddr = compat_GetDeviceProcAddr;
+    pVersionStruct->pfnGetDeviceProcAddr = NULL;
     pVersionStruct->pfnGetPhysicalDeviceProcAddr = NULL;
 
     return VK_SUCCESS;

--- a/vulkan/VkLayer_waydroid_compat.c
+++ b/vulkan/VkLayer_waydroid_compat.c
@@ -27,8 +27,8 @@
  * reports zero feature flags for all ETC2/EAC formats, causing apps
  * to fall back to uncompressed textures.
  *
- * Note: uses a single global dispatch table. This is safe for Waydroid
- * since it only ever creates a single Vulkan instance per container.
+ * Dispatch tables are stored per-instance to correctly handle multiple
+ * VkInstance objects (e.g. from apps and native services).
  */
 
 #include <string.h>
@@ -36,16 +36,54 @@
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
 
+/* ---- Per-instance dispatch ---- */
+
 typedef struct {
     PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
     PFN_vkDestroyInstance DestroyInstance;
-    PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
     PFN_vkGetPhysicalDeviceFormatProperties GetPhysicalDeviceFormatProperties;
     PFN_vkGetPhysicalDeviceFormatProperties2 GetPhysicalDeviceFormatProperties2;
-    PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
 } InstanceDispatch;
 
-static InstanceDispatch g_dispatch;
+typedef struct InstanceDispatchEntry {
+    VkInstance instance;
+    InstanceDispatch dispatch;
+    struct InstanceDispatchEntry *next;
+} InstanceDispatchEntry;
+
+static InstanceDispatchEntry *g_instances = NULL;
+
+static InstanceDispatch *find_instance_dispatch(VkInstance instance)
+{
+    InstanceDispatchEntry *entry = g_instances;
+    while (entry) {
+        if (entry->instance == instance)
+            return &entry->dispatch;
+        entry = entry->next;
+    }
+    return NULL;
+}
+
+/*
+ * The Vulkan loader sets the first pointer-sized field of any dispatchable
+ * handle (VkInstance, VkPhysicalDevice, VkDevice, etc.) to point to the
+ * loader's dispatch table. Physical devices share this key with their
+ * parent instance (the loader guarantees this). We use it to map a
+ * VkPhysicalDevice back to the instance dispatch we stored at creation.
+ */
+static InstanceDispatch *find_phys_dev_dispatch(VkPhysicalDevice physicalDevice)
+{
+    void *key = *(void **)physicalDevice;
+    InstanceDispatchEntry *entry = g_instances;
+    while (entry) {
+        if (*(void **)entry->instance == key)
+            return &entry->dispatch;
+        entry = entry->next;
+    }
+    return NULL;
+}
+
+/* ---- ETC2/EAC format masking ---- */
 
 static int is_etc2_eac_format(VkFormat format)
 {
@@ -89,13 +127,18 @@ static void zero_format_features3(VkFormatProperties2 *pFormatProperties)
     }
 }
 
+/* ---- Intercepted entry points ---- */
+
 static VKAPI_ATTR void VKAPI_CALL
 compat_GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice,
                                          VkFormat format,
                                          VkFormatProperties *pFormatProperties)
 {
-    g_dispatch.GetPhysicalDeviceFormatProperties(physicalDevice, format,
-                                                 pFormatProperties);
+    InstanceDispatch *dispatch = find_phys_dev_dispatch(physicalDevice);
+    if (!dispatch)
+        return;
+    dispatch->GetPhysicalDeviceFormatProperties(physicalDevice, format,
+                                                pFormatProperties);
     if (is_etc2_eac_format(format))
         zero_format_features(pFormatProperties);
 }
@@ -105,15 +148,19 @@ compat_GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice,
                                           VkFormat format,
                                           VkFormatProperties2 *pFormatProperties)
 {
-    g_dispatch.GetPhysicalDeviceFormatProperties2(physicalDevice, format,
-                                                  pFormatProperties);
+    InstanceDispatch *dispatch = find_phys_dev_dispatch(physicalDevice);
+    if (!dispatch)
+        return;
+    dispatch->GetPhysicalDeviceFormatProperties2(physicalDevice, format,
+                                                 pFormatProperties);
     if (is_etc2_eac_format(format)) {
         zero_format_features(&pFormatProperties->formatProperties);
         zero_format_features3(pFormatProperties);
     }
 }
 
-/* Instance creation: set up dispatch chain */
+/* ---- Instance lifecycle ---- */
+
 static VKAPI_ATTR VkResult VKAPI_CALL
 compat_CreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                      const VkAllocationCallbacks *pAllocator,
@@ -147,21 +194,31 @@ compat_CreateInstance(const VkInstanceCreateInfo *pCreateInfo,
     if (result != VK_SUCCESS)
         return result;
 
-    g_dispatch.GetInstanceProcAddr = next_gipa;
-    g_dispatch.DestroyInstance =
+    /* Allocate and populate a per-instance dispatch entry */
+    InstanceDispatchEntry *entry =
+            (InstanceDispatchEntry *)malloc(sizeof(InstanceDispatchEntry));
+    if (!entry) {
+        PFN_vkDestroyInstance destroy =
+                (PFN_vkDestroyInstance)next_gipa(*pInstance, "vkDestroyInstance");
+        if (destroy)
+            destroy(*pInstance, pAllocator);
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    entry->instance = *pInstance;
+    entry->dispatch.GetInstanceProcAddr = next_gipa;
+    entry->dispatch.DestroyInstance =
             (PFN_vkDestroyInstance)next_gipa(*pInstance, "vkDestroyInstance");
-    g_dispatch.EnumeratePhysicalDevices =
-            (PFN_vkEnumeratePhysicalDevices)next_gipa(
-                    *pInstance, "vkEnumeratePhysicalDevices");
-    g_dispatch.GetPhysicalDeviceFormatProperties =
+    entry->dispatch.GetPhysicalDeviceFormatProperties =
             (PFN_vkGetPhysicalDeviceFormatProperties)next_gipa(
                     *pInstance, "vkGetPhysicalDeviceFormatProperties");
-    g_dispatch.GetPhysicalDeviceFormatProperties2 =
+    entry->dispatch.GetPhysicalDeviceFormatProperties2 =
             (PFN_vkGetPhysicalDeviceFormatProperties2)next_gipa(
                     *pInstance, "vkGetPhysicalDeviceFormatProperties2");
-    g_dispatch.EnumerateDeviceExtensionProperties =
-            (PFN_vkEnumerateDeviceExtensionProperties)next_gipa(
-                    *pInstance, "vkEnumerateDeviceExtensionProperties");
+
+    /* Prepend to linked list */
+    entry->next = g_instances;
+    g_instances = entry;
 
     return VK_SUCCESS;
 }
@@ -170,10 +227,23 @@ static VKAPI_ATTR void VKAPI_CALL
 compat_DestroyInstance(VkInstance instance,
                       const VkAllocationCallbacks *pAllocator)
 {
-    if (g_dispatch.DestroyInstance)
-        g_dispatch.DestroyInstance(instance, pAllocator);
-    memset(&g_dispatch, 0, sizeof(g_dispatch));
+    InstanceDispatchEntry **prev = &g_instances;
+    InstanceDispatchEntry *entry = g_instances;
+
+    while (entry) {
+        if (entry->instance == instance) {
+            *prev = entry->next;
+            if (entry->dispatch.DestroyInstance)
+                entry->dispatch.DestroyInstance(instance, pAllocator);
+            free(entry);
+            return;
+        }
+        prev = &entry->next;
+        entry = entry->next;
+    }
 }
+
+/* ---- GetInstanceProcAddr ---- */
 
 __attribute__((visibility("default"))) VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
 compat_GetInstanceProcAddr(VkInstance instance, const char *pName)
@@ -189,12 +259,14 @@ compat_GetInstanceProcAddr(VkInstance instance, const char *pName)
     if (strcmp(pName, "vkGetPhysicalDeviceFormatProperties2KHR") == 0)
         return (PFN_vkVoidFunction)compat_GetPhysicalDeviceFormatProperties2;
 
-    if (g_dispatch.GetInstanceProcAddr)
-        return g_dispatch.GetInstanceProcAddr(instance, pName);
+    InstanceDispatch *dispatch = find_instance_dispatch(instance);
+    if (dispatch)
+        return dispatch->GetInstanceProcAddr(instance, pName);
     return NULL;
 }
 
-/* Layer negotiation (loader interface version 2) */
+/* ---- Layer negotiation (loader interface version 2) ---- */
+
 __attribute__((visibility("default"))) VKAPI_ATTR VkResult VKAPI_CALL
 vkNegotiateLoaderLayerInterfaceVersion(
         VkNegotiateLayerInterface *pVersionStruct)
@@ -215,6 +287,8 @@ vkNegotiateLoaderLayerInterfaceVersion(
 
     return VK_SUCCESS;
 }
+
+/* ---- Layer enumeration ---- */
 
 static const VkLayerProperties layer_props = {
         .layerName = "VK_LAYER_WAYDROID_compat",

--- a/vulkan/VkLayer_waydroid_compat.c
+++ b/vulkan/VkLayer_waydroid_compat.c
@@ -222,21 +222,22 @@ compat_CreateInstance(const VkInstanceCreateInfo *pCreateInfo,
     if (result != VK_SUCCESS)
         return result;
 
+    PFN_vkDestroyInstance destroy_fn =
+            (PFN_vkDestroyInstance)next_gipa(*pInstance, "vkDestroyInstance");
+
     /* Allocate and populate a per-instance dispatch entry */
     InstanceDispatchEntry *entry =
             (InstanceDispatchEntry *)malloc(sizeof(InstanceDispatchEntry));
     if (!entry) {
-        PFN_vkDestroyInstance destroy =
-                (PFN_vkDestroyInstance)next_gipa(*pInstance, "vkDestroyInstance");
-        if (destroy)
-            destroy(*pInstance, pAllocator);
+        LOGE("malloc failed for InstanceDispatchEntry");
+        if (destroy_fn)
+            destroy_fn(*pInstance, pAllocator);
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     entry->instance = *pInstance;
     entry->dispatch.GetInstanceProcAddr = next_gipa;
-    entry->dispatch.DestroyInstance =
-            (PFN_vkDestroyInstance)next_gipa(*pInstance, "vkDestroyInstance");
+    entry->dispatch.DestroyInstance = destroy_fn;
     entry->dispatch.GetPhysicalDeviceFormatProperties =
             (PFN_vkGetPhysicalDeviceFormatProperties)next_gipa(
                     *pInstance, "vkGetPhysicalDeviceFormatProperties");

--- a/vulkan/VkLayer_waydroid_compat.json
+++ b/vulkan/VkLayer_waydroid_compat.json
@@ -1,0 +1,11 @@
+{
+    "file_format_version": "1.0.0",
+    "layer": {
+        "name": "VK_LAYER_WAYDROID_compat",
+        "type": "GLOBAL",
+        "library_path": "/vendor/lib64/vulkan/VkLayer_waydroid_compat.so",
+        "api_version": "1.3.0",
+        "implementation_version": "1",
+        "description": "Waydroid ETC2/EAC format compatibility layer"
+    }
+}

--- a/vulkan/VkLayer_waydroid_compat.json
+++ b/vulkan/VkLayer_waydroid_compat.json
@@ -3,7 +3,7 @@
     "layer": {
         "name": "VK_LAYER_WAYDROID_compat",
         "type": "GLOBAL",
-        "library_path": "/vendor/lib64/vulkan/VkLayer_waydroid_compat.so",
+        "library_path": "VkLayer_waydroid_compat.so",
         "api_version": "1.3.0",
         "implementation_version": "1",
         "description": "Waydroid ETC2/EAC format compatibility layer"

--- a/vulkan/init.vulkan.waydroid.rc
+++ b/vulkan/init.vulkan.waydroid.rc
@@ -1,0 +1,5 @@
+# Enable ETC2/EAC Vulkan compat layer on Intel GPUs.
+# Mesa ANV does not handle AHardwareBuffer with ETC2 formats,
+# causing ARM64 apps to crash with SIGABRT.
+on property:ro.hardware.vulkan=intel
+    setprop debug.vulkan.layers VK_LAYER_WAYDROID_compat


### PR DESCRIPTION
### Problem

ARM64 Unity games crash with SIGABRT when running on Waydroid with Intel GPUs. The crash originates in `AHardwareBuffer_getNativeHandle` because Mesa ANV does not handle `AHardwareBuffer` with ETC2 compressed texture formats through gralloc. When gralloc encounters unsupported format `0x38` (`ETC2_RGB8`), the Vulkan swapchain creation path reaches `AHardwareBuffer_getNativeHandle` with an invalid handle and aborts.

The crash chain is: `UnityMain` calls `vkCreateSwapchainKHR`, which goes through `vulkan::driver::CreateSwapchainKHR` into `vulkan.intel.so`, where `AHardwareBuffer_getNativeHandle` receives a null native handle and triggers a SIGABRT.

### Solution

This adds a Vulkan implicit layer (`VK_LAYER_WAYDROID_compat`) that intercepts `vkGetPhysicalDeviceFormatProperties` and `vkGetPhysicalDeviceFormatProperties2`. For all ETC2/EAC formats, the layer reports zero feature flags (`linearTilingFeatures`, `optimalTilingFeatures`, `bufferFeatures`), which causes apps to detect that ETC2 is not supported and fall back to uncompressed textures. The layer also walks the `pNext` chain to zero out `VkFormatProperties3` when present, ensuring complete coverage for Vulkan 1.3 queries.

Dispatch tables are stored per-instance using a linked list, so the layer correctly handles multiple `VkInstance` objects existing simultaneously (for example from native services alongside applications). All linked list access is protected by a `pthread_mutex_t` for thread safety. The physical device to instance mapping uses the Vulkan loader dispatch key, which is the same approach used by the Khronos validation layers.

An init script automatically sets `debug.vulkan.layers=VK_LAYER_WAYDROID_compat` when `ro.hardware.vulkan=intel` is detected, so no user configuration is required.

### Activation scope (Intel only)

The layer implementation itself is GPU agnostic, but the init script only activates it when `ro.hardware.vulkan=intel` is detected. Other GPU vendors are unaffected at runtime. If someone were to manually enable the layer on AMD or another GPU via `setprop`, it would still function correctly by masking ETC2 formats, but there is no reason to do so since other drivers handle ETC2 through AHardwareBuffer without crashing.

### Format mappings

The layer masks the following ten ETC2/EAC formats. These are the baseline compressed texture formats for Android since OpenGL ES 3.0 and are primarily used by games built for ARM GPUs. Apps that target desktop Vulkan typically do not request ETC2 swapchain images. Games built for ARM with ETC2 as the only texture format will fall back to uncompressed RGBA when the layer is active.

| Format | Vulkan enum |
|---|---|
| ETC2 RGB8 UNORM | `VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK` |
| ETC2 RGB8 SRGB | `VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK` |
| ETC2 RGBA1 UNORM | `VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK` |
| ETC2 RGBA1 SRGB | `VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK` |
| ETC2 RGBA8 UNORM | `VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK` |
| ETC2 RGBA8 SRGB | `VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK` |
| EAC R11 UNORM | `VK_FORMAT_EAC_R11_UNORM_BLOCK` |
| EAC R11 SNORM | `VK_FORMAT_EAC_R11_SNORM_BLOCK` |
| EAC RG11 UNORM | `VK_FORMAT_EAC_R11G11_UNORM_BLOCK` |
| EAC RG11 SNORM | `VK_FORMAT_EAC_R11G11_SNORM_BLOCK` |

### Files

| File | Description |
|------|-------------|
| [vulkan/Android.bp](https://github.com/uzairdeveloper223/android_hardware_waydroid/blob/lineage-20/vulkan/Android.bp) | Soong build rules for the shared library and JSON manifest |
| [vulkan/VkLayer_waydroid_compat.c](https://github.com/uzairdeveloper223/android_hardware_waydroid/blob/lineage-20/vulkan/VkLayer_waydroid_compat.c) | Layer implementation with per-instance dispatch and thread safety |
| [vulkan/VkLayer_waydroid_compat.json](https://github.com/uzairdeveloper223/android_hardware_waydroid/blob/lineage-20/vulkan/VkLayer_waydroid_compat.json) | Layer manifest for the Vulkan loader |
| [vulkan/init.vulkan.waydroid.rc](https://github.com/uzairdeveloper223/android_hardware_waydroid/blob/lineage-20/vulkan/init.vulkan.waydroid.rc) | Init script that auto enables the layer on Intel GPUs |

### Validation done

Tested on Intel i5 8th gen with UHD 620, Ubuntu 24.04, Waydroid with LineageOS 20. Before the fix, ARM64 Unity games (com.MA.LAC) crashed immediately with SIGABRT on launch. After the fix, games launch and run without crashing. Textures fall back to RGBA uncompressed formats. Frame rate and visual output were identical to a reference run with ETC2 disabled in the Unity build settings. No rendering artifacts observed. Non Unity apps and non ETC2 Vulkan workloads are completely unaffected because the layer only modifies queries for the ten formats listed above.

Multi-instance dispatch was verified on the host by compiling the layer and running a test that creates two VkInstance objects, queries ETC2 format properties from the first instance's physical device, and destroys both instances. ETC2 features were correctly zeroed and both instances were destroyed without errors.

```
Creating instance 1...
Creating instance 2...
ETC2 RGB8 features: linear=0 optimal=0 buffer=0
PASS: ETC2 correctly masked
PASS: Both instances destroyed cleanly
```

### Known limitations

The layer does not perform actual ETC2 decompression. It hides format support so that apps use alternative uncompressed formats. This means slightly higher memory usage for textures compared to native ETC2 support, but has no visible impact on rendering quality or frame rate based on testing.

### Why not fix in Mesa?

The correct long term fix is to either add a null check guard in get_ahb_buffer_format_properties2() (prevents the crash) or wire ETC2 through anv_get_compressed_format_emulation() using the existing `vk_texcompress_etc2.h` infrastructure (adds actual support). A Mesa patch for the null check guard has been submitted separately at [waydroid/android_external_mesa3d#12](https://github.com/waydroid/android_external_mesa3d/pull/12). This layer remains useful as an immediate Waydroid side workaround that provides relief for affected users regardless of which Mesa version is deployed.

Fixes waydroid/waydroid#702
Fixes waydroid/waydroid#2187

Signed-off-by: Uzair Mughal <contact@uzair.is-a.dev>