### PR TITLE
hwcomposer/interfaces: Fix building on A14+

### DIFF
--- a/hwcomposer/WaydroidClipboard.cpp
+++ b/hwcomposer/WaydroidClipboard.cpp
@@ -27,7 +27,7 @@
 
 #include <wayland-client.h>
 
-static const std::vector<const std::string> MIME_TYPES = {
+static const std::vector<std::string> MIME_TYPES = {
     "text/plain;charset=utf-8",
     "UTF8_STRING",
     "text/plain",

--- a/interfaces/task/1.0/default/WaydroidTask.cpp
+++ b/interfaces/task/1.0/default/WaydroidTask.cpp
@@ -16,6 +16,7 @@
 
 #include "WaydroidTask.h"
 
+#include <android/api-level.h>
 #include <utils/String16.h>
 #include <utils/String8.h>
 
@@ -69,7 +70,12 @@ Return<void> WaydroidTask::getAppName(const hidl_string& packageName, getAppName
     }
     if (mPlatform != nullptr)
         mPlatform->getAppName(android::String16(packageName.c_str()), &AppName);
-    const char* OutAppName = android::String8(AppName).string();
+    android::String8 AppName8(AppName);
+#if __ANDROID_API__ >= 34
+    const char* OutAppName = AppName8.c_str();
+#else
+    const char* OutAppName = AppName8.string();
+#endif
     if (strlen(OutAppName) == 0)
         OutAppName = packageName.c_str();
     _hidl_cb(OutAppName);


### PR DESCRIPTION
Fixes the following errors:

```cxx
prebuilts/clang/host/linux-x86/clang-r547379/include/c++/v1/__memory/allocator.h:79:17: error: static assertion failed due to requirement '!is_const<const std::string>::value': std::allocator does not support const types
   79 |   static_assert(!is_const<_Tp>::value, "std::allocator does not support const types");
      |                 ^~~~~~~~~~~~~~~~~~~~~
prebuilts/clang/host/linux-x86/clang-r547379/include/c++/v1/__memory/allocator_traits.h:248:39: note: in instantiation of template class 'std::allocator<const std::string>' requested here
  248 |   using value_type         = typename allocator_type::value_type;
      |                                       ^
prebuilts/clang/host/linux-x86/clang-r547379/include/c++/v1/vector:399:20: note: in instantiation of template class 'std::allocator_traits<std::allocator<const std::string>>' requested here
  399 |   typedef typename __alloc_traits::size_type size_type;
      |                    ^
hardware/waydroid/hwcomposer/WaydroidClipboard.cpp:30:45: note: in instantiation of template class 'std::vector<const std::string>' requested here
   30 | static const std::vector<const std::string> MIME_TYPES = {
```

```cxx
hardware/waydroid/interfaces/task/1.0/default/WaydroidTask.cpp:72:56: error: 'string' is a private member of 'android::String8'
   72 |     const char* OutAppName = android::String8(AppName).string();
      |                                                        ^
```