### PR TITLE
hwcomposer: Prevent null pointer dereference on layer buffer handle

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -101,6 +101,9 @@ namespace {
     }
 
     buffer *get_wl_buffer(waydroid_hwc_composer_device_1 *pdev, hwc_layer_1_t *layer, size_t pos) {
+        if (!layer || !layer->handle) {
+            return nullptr;
+        }
         const auto& gralloc_handler = pdev->gralloc_handler;
         auto metadata = gralloc_handler.get_buffer_metadata(pdev->display, layer, pos);
         if (!metadata.format) {

--- a/hwcomposer/modes/waydroid_mode_impl.h
+++ b/hwcomposer/modes/waydroid_mode_impl.h
@@ -158,10 +158,12 @@ class non_compositing_window_mode : public virtual waydroid_mode {
          */
         int res = 0;
         if (i == m_draw_framebuffer_at) {
-            assert(m_framebuffer_target->handle);
-            window *window = derived()->get_window(pdev);
-
-            res = apply_hwc_layer_to_window(pdev, m_framebuffer_target, m_framebuffer_target_index, window);
+            if (m_framebuffer_target && m_framebuffer_target->handle) {
+                window *window = derived()->get_window(pdev);
+                res = apply_hwc_layer_to_window(pdev, m_framebuffer_target, m_framebuffer_target_index, window);
+            } else {
+                ALOGW("m_framebuffer_target is not ready or has null handle");
+            }
         }
 
         // The acquireFenceFd of HWC_FRAMEBUFFER_TARGET is closed in apply_hwc_layer_to_window


### PR DESCRIPTION
The hwcomposer (waydroid_mode_impl.h) and graphics com[poser crash intermittently when a layer or framebuffer target is processed with a null buffer handle.