### PR TITLE
hwcomposer: follow output scale changes instead of latching at boot

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -583,7 +583,12 @@ static int32_t hwc_attribute(struct waydroid_hwc_composer_device_1* pdev,
         }
         case HWC_DISPLAY_DPI_X:
         case HWC_DISPLAY_DPI_Y:
-            if (property_get("ro.sf.lcd_density", property, nullptr) > 0)
+            // Prefer the live value: ro.sf.lcd_density is read-only and keeps
+            // whatever was published at boot, so it cannot follow a warm output
+            // scale change. display->density is kept in step with the scale.
+            if (pdev->display->density > 0)
+                density = pdev->display->density;
+            else if (property_get("ro.sf.lcd_density", property, nullptr) > 0)
                 density = atoi(property);
             return density * 1000;
         case HWC_DISPLAY_COLOR_TRANSFORM:

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -79,6 +79,7 @@
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "xdg-output-unstable-v1-client-protocol.h"
 
 using ::android::hardware::hidl_string;
 
@@ -196,6 +197,40 @@ do_hotplug(struct display *display) {
         display->needHotplug = true;
         display->procs->invalidate(display->procs);
     }
+}
+
+/*
+ * Apply a new output scale to a *calibrated* display: publish it, keep the
+ * reported DPI in step, re-derive the display size from the compositor's
+ * logical size, and hotplug so SurfaceFlinger re-reads the config. The goal is
+ * that a warm scale change converges on the same state a fresh boot at that
+ * scale would produce.
+ */
+void
+apply_scale_change(struct display *display, double new_scale)
+{
+    if (new_scale <= 0 || new_scale == display->scale)
+        return;
+
+    ALOGI("output scale changed: %f -> %f", display->scale, new_scale);
+    display->scale = new_scale;
+
+    /* Before the first window has calibrated the display, window::create()
+     * publishes the scale and sizes the display itself. */
+    if (!display->width || !display->height)
+        return;
+
+    std::string display_scale = std::to_string(display->scale);
+    property_set("waydroid.display_scale", display_scale.c_str());
+
+    /* display->width/height are logical; the physical size is width * scale.
+     * Re-derive from the compositor's current logical size when we know it so
+     * the physical size keeps matching the output instead of being scaled a
+     * second time. */
+    if (display->logical_width > 0 && display->logical_height > 0)
+        choose_width_height(display, display->logical_width, display->logical_height);
+
+    do_hotplug(display);
 }
 
 static void
@@ -429,6 +464,7 @@ void window::minimize() {
 }
 
 window::~window() {
+    display->live_windows--;
     if (fractional_scale)
         wp_fractional_scale_v1_destroy(fractional_scale);
     if (xdg_toplevel)
@@ -468,24 +504,10 @@ static void fractional_scale_handle_preferred_scale(void *data, struct wp_fracti
         return;
     }
 
-    double new_scale = scale_times_120 / 120.0;
-    if (new_scale == display->scale)
-        return;
-    display->scale = new_scale;
-
-    // Before the first window has calibrated the display, window::create()
-    // publishes the scale and configures the Android display itself, so there
-    // is nothing to reconfigure yet.
-    if (!display->width || !display->height)
-        return;
-
-    // Warm output-scale change: keep waydroid.display_scale in sync and force a
-    // recomposition so every surface (new and existing) is re-committed with a
-    // buffer scale / viewport consistent with the compositor's current scale.
-    // Without this the value latched at boot would be used forever.
-    std::string display_scale = std::to_string(display->scale);
-    property_set("waydroid.display_scale", display_scale.c_str());
-    do_hotplug(display);
+    // preferred_scale is per-surface and therefore the authoritative scale
+    // whenever a surface exists: it reflects the output the surface is actually
+    // on, which the globally-bound wl_output/xdg_output may not be.
+    apply_scale_change(display, scale_times_120 / 120.0);
 }
 
 static const struct wp_fractional_scale_v1_listener fractional_scale_listener = {
@@ -500,6 +522,7 @@ window::create(struct display *display, bool use_subsurfaces, std::string appID,
         return nullptr;
 
     window->display = display;
+    display->live_windows++;
     window->surface = wl_compositor_create_surface(display->compositor);
     wl_surface_set_user_data(window->surface, window.get());
     if (display->viewporter)
@@ -587,11 +610,18 @@ window::create(struct display *display, bool use_subsurfaces, std::string appID,
 
         // If after all of this we still did not receive a proper configure event,
         // fallback to using the full output size.
-        // NOTICE: full_width and full_heigth should be in compositor logical size!
+        // NOTICE: req_width/req_height are in compositor *logical* size!
+        // xdg_output reports exactly that, so prefer it. wl_output.mode is in
+        // physical pixels, so the fallback has to divide it by the scale - which
+        // silently bakes in a wrong size if the scale is not yet known.
         if (!display->req_height)
-            display->req_height = display->full_height / display->scale;
+            display->req_height = display->logical_height
+                                ? display->logical_height
+                                : int(display->full_height / display->scale);
         if (!display->req_width)
-            display->req_width = display->full_width / display->scale;
+            display->req_width = display->logical_width
+                               ? display->logical_width
+                               : int(display->full_width / display->scale);
 
         finished_calibrating(display);
         if (!display->isMaximized)
@@ -1505,6 +1535,80 @@ static const struct wl_output_listener output_listener = {
     output_handle_scale,
 };
 
+/*
+ * xdg_output gives us the output size in the compositor's *logical* coordinate
+ * space. Together with wl_output.mode (physical pixels) that yields the true
+ * fractional scale without needing a mapped surface, which is the only way to
+ * follow a scale change while no app window exists (preferred_scale is only
+ * ever delivered for a surface that is actually mapped).
+ */
+static void
+xdg_output_handle_logical_size(void *data, struct zxdg_output_v1 *,
+            int32_t width, int32_t height)
+{
+    struct display *d = (struct display *)data;
+    if (width <= 0 || height <= 0)
+        return;
+    d->logical_width = width;
+    d->logical_height = height;
+}
+
+static void
+xdg_output_handle_logical_position(void *, struct zxdg_output_v1 *,
+            int32_t, int32_t)
+{
+}
+
+static void
+xdg_output_handle_done(void *data, struct zxdg_output_v1 *)
+{
+    struct display *d = (struct display *)data;
+
+    if (!d->logical_width || !d->full_width)
+        return;
+
+    // Only trust this while no surface exists. With a surface mapped,
+    // preferred_scale is authoritative (it tracks the output that surface is
+    // actually on); applying both on a mixed-DPI multi-output setup would make
+    // the two sources fight each other.
+    if (d->live_windows.load() != 0)
+        return;
+
+    apply_scale_change(d, (double)d->full_width / (double)d->logical_width);
+}
+
+static void
+xdg_output_handle_name(void *, struct zxdg_output_v1 *, const char *)
+{
+}
+
+static void
+xdg_output_handle_description(void *, struct zxdg_output_v1 *, const char *)
+{
+}
+
+static const struct zxdg_output_v1_listener xdg_output_listener = {
+    xdg_output_handle_logical_position,
+    xdg_output_handle_logical_size,
+    xdg_output_handle_done,
+    xdg_output_handle_name,
+    xdg_output_handle_description,
+};
+
+/*
+ * The xdg_output manager and the wl_output can be advertised in either order,
+ * so hook them up as soon as we have both.
+ */
+void
+maybe_create_xdg_output(struct display *d)
+{
+    if (d->xdg_output || !d->xdg_output_manager || !d->output)
+        return;
+    d->xdg_output = zxdg_output_manager_v1_get_xdg_output(d->xdg_output_manager, d->output);
+    zxdg_output_v1_add_listener(d->xdg_output, &xdg_output_listener, d);
+    ALOGI("xdg_output: bound, will track output scale without a mapped surface");
+}
+
 static void
 presentation_clock_id(void *, struct wp_presentation *,
               uint32_t clk_id)
@@ -1939,7 +2043,15 @@ registry_handle_global(void *data, struct wl_registry *registry,
         d->output = (struct wl_output*)wl_registry_bind(registry, id,
                 &wl_output_interface, std::min(version, 3U));
         wl_output_add_listener(d->output, &output_listener, d);
+        maybe_create_xdg_output(d);
         wl_display_roundtrip(d->display);
+    } else if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0) {
+        // Bind at most version 2: version 3 deprecates zxdg_output_v1.done (the
+        // compositor sends wl_output.done instead), and we rely on done to know
+        // when a logical_size update is complete.
+        d->xdg_output_manager = (struct zxdg_output_manager_v1*)wl_registry_bind(registry, id,
+                &zxdg_output_manager_v1_interface, std::min(version, 2U));
+        maybe_create_xdg_output(d);
     } else if (strcmp(interface, "wp_presentation") == 0) {
         bool no_presentation = property_get_bool("persist.waydroid.no_presentation", false);
         if (!no_presentation) {

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -166,7 +166,13 @@ finished_calibrating(struct display *d)
     if (property_get("ro.sf.lcd_density", property, nullptr) <= 0) {
         std::string lcd_density = std::to_string(int(default_density * d->scale));
         property_set("ro.sf.lcd_density", lcd_density.c_str());
+        d->density = int(default_density * d->scale);
+    } else {
+        d->density = atoi(property);
     }
+    /* Remember the unscaled density so a later scale change can re-derive the
+     * DPI the same way a fresh boot at that scale would. */
+    d->base_density = d->scale > 0 ? int(round(d->density / d->scale)) : default_density;
 
     choose_width_height(d, d->req_width, d->req_height);
 }
@@ -222,6 +228,11 @@ apply_scale_change(struct display *display, double new_scale)
 
     std::string display_scale = std::to_string(display->scale);
     property_set("waydroid.display_scale", display_scale.c_str());
+
+    /* ro.sf.lcd_density is read-only and keeps its boot value, so the live DPI
+     * is carried in display->density, which hwc_attribute() reports. */
+    if (display->base_density > 0)
+        display->density = int(round(display->base_density * display->scale));
 
     /* display->width/height are logical; the physical size is width * scale.
      * Re-derive from the compositor's current logical size when we know it so

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -429,6 +429,8 @@ void window::minimize() {
 }
 
 window::~window() {
+    if (fractional_scale)
+        wp_fractional_scale_v1_destroy(fractional_scale);
     if (xdg_toplevel)
         xdg_toplevel_destroy(xdg_toplevel);
     if (xdg_surface)
@@ -465,7 +467,25 @@ static void fractional_scale_handle_preferred_scale(void *data, struct wp_fracti
         // but for debugging purpuses we may decide to disable one
         return;
     }
-    display->scale = scale_times_120 / 120.0;
+
+    double new_scale = scale_times_120 / 120.0;
+    if (new_scale == display->scale)
+        return;
+    display->scale = new_scale;
+
+    // Before the first window has calibrated the display, window::create()
+    // publishes the scale and configures the Android display itself, so there
+    // is nothing to reconfigure yet.
+    if (!display->width || !display->height)
+        return;
+
+    // Warm output-scale change: keep waydroid.display_scale in sync and force a
+    // recomposition so every surface (new and existing) is re-committed with a
+    // buffer scale / viewport consistent with the compositor's current scale.
+    // Without this the value latched at boot would be used forever.
+    std::string display_scale = std::to_string(display->scale);
+    property_set("waydroid.display_scale", display_scale.c_str());
+    do_hotplug(display);
 }
 
 static const struct wp_fractional_scale_v1_listener fractional_scale_listener = {
@@ -484,6 +504,16 @@ window::create(struct display *display, bool use_subsurfaces, std::string appID,
     wl_surface_set_user_data(window->surface, window.get());
     if (display->viewporter)
         window->viewport = wp_viewporter_get_viewport(display->viewporter, window->surface);
+    // Keep a fractional-scale object alive for the whole surface (not just during
+    // calibration) so the compositor keeps telling us when the output scale
+    // changes while the session is warm. We only support one global scale, so
+    // every surface reports into the same display->scale.
+    if (display->fractional_scale_manager) {
+        window->fractional_scale = wp_fractional_scale_manager_v1_get_fractional_scale(
+                display->fractional_scale_manager, window->surface);
+        wp_fractional_scale_v1_add_listener(window->fractional_scale,
+                &fractional_scale_listener, display);
+    }
     window->taskID = std::move(taskID);
     window->dedicated_background_surface = true;
     window->bg_buffer = nullptr;
@@ -544,14 +574,6 @@ window::create(struct display *display, bool use_subsurfaces, std::string appID,
     } while (!window->configured);
 
     if (calibrating) {
-        wp_fractional_scale_v1* fs = nullptr;
-        if (display->fractional_scale_manager) {
-            // We only support one global scale
-            fs = wp_fractional_scale_manager_v1_get_fractional_scale(
-                    display->fractional_scale_manager, window->surface);
-            wp_fractional_scale_v1_add_listener(fs, &fractional_scale_listener, display);
-        }
-
         // Some compositors fail to give us a window size or scale without a buffer attached
         // See: https://github.com/swaywm/sway/issues/2176
         // Some other compositors may refine the window size after a buffer is attached (Hyprland)
@@ -562,10 +584,6 @@ window::create(struct display *display, bool use_subsurfaces, std::string appID,
             wp_viewport_set_destination(window->viewport, display->req_width, display->req_height);
         wl_surface_commit(window->surface);
         wl_display_roundtrip(display->display);
-
-        if (fs) {
-            wp_fractional_scale_v1_destroy(fs);
-        }
 
         // If after all of this we still did not receive a proper configure event,
         // fallback to using the full output size.
@@ -1464,6 +1482,19 @@ output_handle_scale(void *data, struct wl_output *,
             int32_t scale)
 {
     struct display *d = (struct display*)data;
+    if (d->fractional_scale_manager) {
+        // wl_output.scale only carries the legacy *integer* scale: a compositor
+        // using fractional scaling reports ceil() here (e.g. 2 for 1.5). Feeding
+        // that through std::max() latches the display at the ceiling forever once
+        // the output is ever bumped to a fractional scale and back, which halves
+        // every subsequent surface on a scale-1 output. When fractional scaling is
+        // available the authoritative value comes from
+        // wp_fractional_scale_v1.preferred_scale, so only use this as an initial
+        // fallback (in case preferred_scale never arrives) and otherwise ignore it.
+        if (d->scale == 0)
+            d->scale = scale;
+        return;
+    }
     d->scale = std::max((int)d->scale, scale);
 }
 

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -42,6 +42,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <errno.h>
+#include <atomic>
 #include <map>
 #include <list>
 #include <set>
@@ -329,12 +330,27 @@ struct display {
     struct zwp_relative_pointer_v1 *relative_pointer;
     struct zwp_idle_inhibit_manager_v1 *idle_manager;
     struct wp_fractional_scale_manager_v1 *fractional_scale_manager;
+    struct zxdg_output_manager_v1 *xdg_output_manager;
+    struct zxdg_output_v1 *xdg_output;
     struct wl_data_device_manager *data_device_manager;
     struct wl_data_device *data_device;
 
     int system_version;
     GrallocType gtype;
     double scale;
+
+    /* Output geometry in the compositor's *logical* coordinate space, from
+     * xdg_output. Unlike wl_output.mode (which is in physical pixels) this lets
+     * us derive the fractional scale without a mapped surface, and gives
+     * window::create() a correct size to fall back on. 0 until we get one. */
+    int logical_width;
+    int logical_height;
+
+    /* Number of live windows. preferred_scale is per-surface and is the
+     * authoritative scale whenever any surface exists; the xdg_output-derived
+     * scale is only applied when there is none (otherwise the two can disagree
+     * on a mixed-DPI multi-output setup and fight each other). */
+    std::atomic<int> live_windows;
 
     int input_fd[INPUT_TOTAL];
     int ptrPrvX;

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -346,6 +346,13 @@ struct display {
     int logical_width;
     int logical_height;
 
+    /* Density bookkeeping so a warm scale change can keep the reported DPI in
+     * step with the scale, exactly as a fresh boot at that scale would.
+     * ro.sf.lcd_density is a read-only property and cannot be re-set once the
+     * boot value is published, so hwc_attribute() reports `density` instead. */
+    int density;
+    int base_density;
+
     /* Number of live windows. preferred_scale is per-surface and is the
      * authoritative scale whenever any surface exists; the xdg_output-derived
      * scale is only applied when there is none (otherwise the two can disagree

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -193,6 +193,10 @@ struct window {
     bool dedicated_background_surface;
     struct wl_surface *surface;
     struct wp_viewport *viewport;
+    /* Kept for the lifetime of the surface so the compositor keeps delivering
+     * wp_fractional_scale_v1.preferred_scale events (used to track live output
+     * scale changes, not just the value latched at boot). */
+    struct wp_fractional_scale_v1 *fractional_scale;
     struct wl_buffer *bg_buffer;
     struct zwp_locked_pointer_v1 *locked_pointer;
 


### PR DESCRIPTION
## Summary

On a compositor using fractional scaling, the hwcomposer never lowers its cached
output scale once it has been raised. If the output scale is ever bumped to a
fractional value and back — a mixed-DPI multi-monitor setup, a suspend/resume, a
display re-plug, or a kiosk showing a scale-1.5 UI between Android activities —
the cached scale latches at the integer *ceiling*. Every surface created
afterwards is then presented at **half size on each axis** (i.e. filling one
quarter of the screen), top-left anchored, until a full `waydroid session
stop`/`start`.

Android-side state stays correct throughout (display size, density, task
bounds); only the Wayland presentation is wrong.

<img width="1830" height="1110" alt="comparison" src="https://github.com/user-attachments/assets/2b9958ae-0cdc-4de2-9cd2-bb7164f85aa7" />

This PR makes the scale actually track the compositor:

1. the legacy integer `wl_output.scale` no longer latches the cached scale,
2. `wp_fractional_scale_v1.preferred_scale` is followed for the life of every
   surface (not just during boot calibration),
3. `xdg_output` is used to follow scale changes even when **no surface is
   mapped**, and
4. a scale change now reconfigures the display instead of only being cached.

## Reproduction

Any wlroots-based compositor with `wp_fractional_scale_manager_v1` (sway below),
`persist.waydroid.multi_windows=true`, any app:

```sh
OUT=HEADLESS-1
APP=com.android.settings

swaymsg "output $OUT scale 1"
waydroid session start &            # wait for sys.boot_completed == 1
waydroid app launch $APP            # correct: fills the display

waydroid shell am force-stop $APP
swaymsg "output $OUT scale 1.5"; sleep 5
swaymsg "output $OUT scale 1";   sleep 2

waydroid app launch $APP            # BUG: renders at half size, top-left
```

Also reproduces with the flips queued across an `lxc-freeze`/`lxc-unfreeze` (the
events replay on thaw), so there is no event-ordering workaround.

This is very likely the same root cause as [**#1347**](https://github.com/waydroid/waydroid/issues/1347) ("Waydroid only displaying
in one quarter of the screen", mixed-DPI 2.0 + 1.0 on labwc, with reporters
noting it appears/disappears across display power-cycles and suspend/resume).

## Root cause

Two things combine, both in `hwcomposer/wayland-hwc.cpp`:

1. **`output_handle_scale()` latched monotonically.**

   ```c
   d->scale = std::max((int)d->scale, scale);
   ```

   `wl_output.scale` carries the **legacy integer** scale — a compositor using
   fractional scaling reports `ceil()` here (2 for a 1.5 output). With the
   `std::max`, once the output goes to 1.5 (event → 2) and back to 1 (event →
   1), the scale stays pinned at 2 forever. It also makes the outcome
   independent of event ordering, which is why a frozen-container replay
   poisons identically, and why a *mixed-DPI multi-output* setup latches onto
   the highest-scale output even when the window is on the scale-1 one.

   With `set_buffer_scale = ceil(2) = 2` on a scale-1 output, every surface is
   halved on each axis — the observed failure (a 1920 px render occupies 960).

2. **The `wp_fractional_scale_v1` object was destroyed after boot calibration**,
   so no `preferred_scale` ever arrived while the session was warm and nothing
   corrected the latch.

## Changes

- **`output_handle_scale()`** — when `wp_fractional_scale_manager_v1` is
  available, the legacy integer scale is only used to *seed* an initial value
  and is otherwise ignored. Behavior is unchanged when the compositor has no
  fractional-scale manager.
- **Per-surface `wp_fractional_scale_v1` kept for the window's lifetime**
  (`window::fractional_scale`), so `preferred_scale` keeps arriving. This is the
  authoritative source whenever a surface exists, since it reflects the output
  that surface is actually on.
- **`xdg_output` support** — the scale is also derived from
  `xdg_output.logical_size` vs `wl_output.mode` (1920/1280 = 1.5). This is the
  only way to follow a scale change while **no** surface is mapped, since
  `preferred_scale` is only delivered for mapped surfaces. It is applied only
  when there are no live windows, so it never fights `preferred_scale` on a
  mixed-DPI multi-output setup.
  *Note: `zxdg_output_manager_v1` is bound at version ≤ 2 on purpose — version 3
  deprecates `zxdg_output_v1.done`, which we rely on.*
- **`apply_scale_change()`** — a single path used by both sources: publish
  `waydroid.display_scale`, keep the reported DPI in step, re-derive the display
  size from the compositor's logical size, and hotplug so SurfaceFlinger re-reads
  the config.
- **Calibration fallback now prefers the real logical size.** `full_width` comes
  from `wl_output.mode` and is in *physical* pixels, so the old fallback divided
  it by the scale — baking in a wrong size whenever the scale was not yet known.
  `xdg_output` reports logical size directly. (This is the `NOTICE` the code
  already carried in `output_handle_mode`, and the same class of problem as
  #1867.)

## Validation

### Claude's testing

Built from source and run in a live session under headless sway (wlroots,
1920×1080, LineageOS 20 x86_64), measured from `grim` captures of the output.

| Check | Before | After |
|---|---|---|
| Boot @1, flip 1→1.5→1, relaunch | **49%×49% (half each axis)** | **98%/99% — identical to fresh boot** |
| Same, flips queued across `lxc-freeze`/`unfreeze` | broken | identical |
| 4 consecutive kiosk close/reopen cycles | broken | all identical, scale steady |
| `display_scale` tracking, surface mapped | never updated | 1.0↔1.5 within ~2 s |
| `display_scale` tracking, **no surface mapped** | never updated | tracks 1.5 / 2.0 / 1.0 |
| Boot @1.5 (physical mode 1920×1080) | `wm size` 1920×1080, density 270 | unchanged (no regression) |

### Human testing

Run on a Microsoft Surface Pro (1920x1080, DPI 1.5) in Sway.

Pardon the camera -- the kiosk setup does not lend itself well to direct screen grab.

#### Before

https://github.com/user-attachments/assets/4a2b1fcc-dd28-4b48-b68e-6841de51f1f5

#### After

https://github.com/user-attachments/assets/444875bc-590f-49c0-b48c-ab26749695d9

## Scope / known limitations

- **No behavioral change** for compositors without
  `wp_fractional_scale_manager_v1`.
- **Live density is not changed.** `ro.sf.lcd_density` is a read-only property
  and keeps its boot value, so the live DPI is carried in `display->density` and
  reported from `hwc_attribute()`. That does not move WindowManager's density:
  changing it live needs `setForcedDisplayDensityForUser`, a framework API that
  a vendor HAL cannot reach (and `IWaydroidTask` exposes no density method). So
  a warm scale change converges on the correct geometry and presentation, but
  not on the UI *zoom* a fresh boot at that scale would give. Closing that gap
  needs a platform-side hook and is left out of this PR.
- **Unrelated pre-existing bug, not addressed here:** `persist.waydroid.width` /
  `height` are treated as *logical* units and then multiplied by the scale, so
  pinning them to the physical mode double-applies the scale (1920 pinned at
  scale 1.5 → `wm size` 2880×1620). Verified identical on an unpatched build.
  Worth its own issue; workaround is to pin the logical size (1280×720 at 1.5)
  or leave them unset.

## Test environment

### Claude's testing

- Waydroid 1.6.2, LineageOS 20 / Android 13 x86_64, vendor MAINLINE.
- sway (wlroots), headless output, pixman renderer.
- `persist.waydroid.multi_windows=true`.

### Human testing

* Microsoft Surface Pro (original): 1920x1080 at DPI 1.5
* Same Waydroid/LineageOS as above
* sway (wlroots) via [shepherd-launcher](https://git.armeafamily.com/albert/shepherd-launcher) on `u/albert/2/android-activity`/[#75](https://git.armeafamily.com/albert/shepherd-launcher/pulls/75)

## Generative AI disclosure

I discovered this issue (quarter scale in the top left) manually while developing Android app support for [shepherd-launcher](https://git.armeafamily.com/albert/shepherd-launcher). I then prompted Claude Code to first investigate my repository, then here once that was inconclusive. This PR is my attempt to upstream the fix.

Please let me know if you have any concerns with this -- I'm happy to split this up, go into more detail about any part, perform additional manual testing, prep a similar change against Lineage 23, etc.