### PR TITLE
hwcomposer: Fix per-frame acquire fence fd leaks

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -375,6 +375,7 @@ static int apply_hwc_layer_to_surface_context(waydroid_hwc_composer_device_1 *pd
 out:
     if (hwc_layer->acquireFenceFd != -1) {
         close(hwc_layer->acquireFenceFd);
+        hwc_layer->acquireFenceFd = -1;
     }
     return res;
 }
@@ -385,6 +386,7 @@ int apply_hwc_layer_to_window(waydroid_hwc_composer_device_1 *pdev, hwc_layer_1 
         ALOGE("Failed to get wayland buffer");
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         return -1;
     }
@@ -460,8 +462,11 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
             found_cursor = true;
             pdev->display->cursor_handler->apply_cursor(pdev, layer, l);
         } else {
-            if (layer->handle)
-                mode->handle_layer(pdev, layer, l);
+            /* No handle check here: modes must see every layer, both to
+             * close its acquire fence and because the framebuffer target
+             * is drawn at the position of a skipped layer, which usually
+             * has no buffer handle of its own. */
+            mode->handle_layer(pdev, layer, l);
         }
     }
     if (!found_cursor) {
@@ -469,6 +474,36 @@ static int hwc_set(struct hwc_composer_device_1* dev,size_t numDisplays,
     }
 
     mode->post_processing(pdev, contents);
+
+    /* Every close path above resets acquireFenceFd to -1, so any fence
+     * still open here was missed by all of them: close it so it cannot
+     * exhaust the fd table, and log which layer leaked it. */
+    for (size_t l = 0; l < contents->numHwLayers; l++) {
+        auto *layer = &contents->hwLayers[l];
+        if (layer->acquireFenceFd != -1) {
+            /* Rate-limited: a leak here fires every frame */
+            static unsigned leaks = 0;
+            if (leaks++ % 1024 == 0) {
+                char apps[PROPERTY_VALUE_MAX];
+                property_get("waydroid.active_apps", apps, "none");
+                ALOGE("hwc_set: unclosed acquire fence %d on layer %zu "
+                      "(compositionType %d flags %#x handle %p, %u total, "
+                      "numHwLayers %zu, should_compose %d multi %d apps '%s')",
+                      layer->acquireFenceFd, l, layer->compositionType,
+                      layer->flags, layer->handle, leaks,
+                      contents->numHwLayers, pdev->should_compose,
+                      pdev->multi_windows, apps);
+            }
+            close(layer->acquireFenceFd);
+            layer->acquireFenceFd = -1;
+        }
+    }
+    if (contents->outbufAcquireFenceFd != -1) {
+        ALOGE("hwc_set: unclosed outbuf acquire fence %d",
+              contents->outbufAcquireFenceFd);
+        close(contents->outbufAcquireFenceFd);
+        contents->outbufAcquireFenceFd = -1;
+    }
 
     for (auto& [key, window] : pdev->display->windows) {
         if (window->input_region) {
@@ -848,6 +883,7 @@ int subsurface_cursor_handler::apply_cursor(waydroid_hwc_composer_device_1* pdev
     if (!pdev->display->pointer_surface) {
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         clear_previous_subsurface_if_needed(pdev);
         return 0;
@@ -863,6 +899,7 @@ int subsurface_cursor_handler::apply_cursor(waydroid_hwc_composer_device_1* pdev
     if (window_it == pdev->display->windows.end()) {
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         clear_previous_subsurface_if_needed(pdev);
         return 0;

--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -924,6 +924,10 @@ int wl_cursor_cursor_handler::apply_cursor(waydroid_hwc_composer_device_1* pdev,
             return -1;
         }
         set_cursor(pdev->display);
+    } else if (hwc_layer->acquireFenceFd != -1) {
+        /* Not rendering the cursor still leaves us owning its fence */
+        close(hwc_layer->acquireFenceFd);
+        hwc_layer->acquireFenceFd = -1;
     }
     return 0;
 }

--- a/hwcomposer/modes/closed.cpp
+++ b/hwcomposer/modes/closed.cpp
@@ -34,6 +34,7 @@ int closed_mode::cleanup_stale_windows(waydroid_hwc_composer_device_1* pdev,
 int closed_mode::handle_layer(waydroid_hwc_composer_device_1 *, hwc_layer_1* hwc_layer, size_t) {
     if (hwc_layer->acquireFenceFd != -1) {
         close(hwc_layer->acquireFenceFd);
+        hwc_layer->acquireFenceFd = -1;
     }
     return 0;
 }

--- a/hwcomposer/modes/multi-window.cpp
+++ b/hwcomposer/modes/multi-window.cpp
@@ -57,7 +57,8 @@ window *multi_window_mode::get_window(waydroid_hwc_composer_device_1 *pdev, laye
 }
 
 bool multi_window_mode::can_handle_layer(const hwc_layer_1& layer) {
-    return layer.compositionType == HWC_OVERLAY && !(layer.flags & HWC_SKIP_LAYER);
+    return layer.compositionType == HWC_OVERLAY && !(layer.flags & HWC_SKIP_LAYER)
+           && layer.handle;
 }
 
 int multi_window_mode::prepare(hwc_layer_1* hwc_layer, size_t) {
@@ -101,6 +102,7 @@ int multi_window_mode::handle_layer(waydroid_hwc_composer_device_1* pdev, hwc_la
         }
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         return 0;
     }
@@ -113,6 +115,7 @@ int multi_window_mode::handle_layer(waydroid_hwc_composer_device_1* pdev, hwc_la
     } else {
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         return 0;
     }

--- a/hwcomposer/modes/single-window.cpp
+++ b/hwcomposer/modes/single-window.cpp
@@ -111,6 +111,7 @@ int non_compositing_single_window_mode::handle_layer(waydroid_hwc_composer_devic
     if (!should_show()) {
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         return 0;
     }
@@ -130,6 +131,7 @@ int compositing_single_window_mode::handle_layer(waydroid_hwc_composer_device_1*
     if (!should_show()) {
         if (hwc_layer->acquireFenceFd != -1) {
             close(hwc_layer->acquireFenceFd);
+            hwc_layer->acquireFenceFd = -1;
         }
         return 0;
     }

--- a/hwcomposer/modes/waydroid_mode_impl.h
+++ b/hwcomposer/modes/waydroid_mode_impl.h
@@ -69,6 +69,7 @@ class compositing_window_mode : public virtual waydroid_mode {
             // Draw the content composited by SurfaceFlinger here
             if (hwc_layer->acquireFenceFd != -1) {
                 close(hwc_layer->acquireFenceFd);
+                hwc_layer->acquireFenceFd = -1;
             }
 
             hwc_layer = skipped_layers.framebuffer_target_layer();
@@ -77,6 +78,7 @@ class compositing_window_mode : public virtual waydroid_mode {
         } else if (skipped_layers.first_skipped() < i && i <= skipped_layers.last_skipped()) {
             if (hwc_layer->acquireFenceFd != -1) {
                 close(hwc_layer->acquireFenceFd);
+                hwc_layer->acquireFenceFd = -1;
             }
             return 0;
         } else if (hwc_layer == skipped_layers.framebuffer_target_layer()) {
@@ -90,6 +92,7 @@ class compositing_window_mode : public virtual waydroid_mode {
              */
             if (!skipped_layers.has_skipped_layers() && hwc_layer->acquireFenceFd != -1) {
                 close(hwc_layer->acquireFenceFd);
+                hwc_layer->acquireFenceFd = -1;
             }
             return 0;
         } else if (hwc_layer->compositionType != HWC_OVERLAY) {
@@ -97,6 +100,7 @@ class compositing_window_mode : public virtual waydroid_mode {
             // TODO: Support HWC_BACKGROUND
             if (hwc_layer->acquireFenceFd != -1) {
                 close(hwc_layer->acquireFenceFd);
+                hwc_layer->acquireFenceFd = -1;
             }
             return 0;
         } else if (!hwc_layer->handle) {
@@ -168,6 +172,15 @@ class non_compositing_window_mode : public virtual waydroid_mode {
         if (i != m_framebuffer_target_index) {
             if (hwc_layer->acquireFenceFd != -1) {
                 close(hwc_layer->acquireFenceFd);
+                hwc_layer->acquireFenceFd = -1;
+            }
+        } else if (i != m_draw_framebuffer_at) {
+            /* The framebuffer target was not drawn this frame (the draw
+             * position layer never reached handle_layer), but the adapter
+             * still handed us a fresh dup of its fence. */
+            if (hwc_layer->acquireFenceFd != -1) {
+                close(hwc_layer->acquireFenceFd);
+                hwc_layer->acquireFenceFd = -1;
             }
         }
         return res;


### PR DESCRIPTION
Hi,
I wanted smooth momentum-based scrolling in Waydroid on trackpads, and thought I'd talk to Claude Fable 5 about the feasibility of this, and one thing led to another, and later that night I had fixes for Waydroid dying after minutes of use with the new smooth scrolling code. This PR is Claude's work on the fd leak. The leak is more noticable when scrolling/flinging at high momentum, especially at 120Hz. This is the PR that Claude suggested creating first, as it compliments the actual 1:1 touch-based smooth scrolling PR that goes with it.

I was hesitant of actually creating these PRs, as I'm on the autistic spectrum (and have severe anxiety) and mostly keep to myself, rarely making PRs. Especially such complicated PRs made with AI. I've made a couple or so AI PRs, but they were much smaller, and I understood them far better. I am actually a developer, but my background is iOS and Mac app development. I recently switched to Android and Linux, as I wasn't happy with how Apple was treating developers, and how closed their app ecosystem was. AI has helped me get up to speed with user Android app development, but this Android system hardware level code is kinda beyond my pay grade. My Dad is a C++ developer, but not with Android background. He has read these PRs' code, but he doesn't know this codebase. I'm only posting these PR's because it'd be a shame for these real leak fixes, and the scrolling feature to not at least have a chance of making it into Waydroid's code.

Claude did make a crash diagnostics PR that goes with these 2. I'm going to post it, but don't feel the need to use it. It raises the fd-limit, I'm not sure whether this would be to your taste. Plus, it puts a log file in the data directory, again not sure how you feel about this.

Obviously this code is riddled with AI comments, it looks like most of your code has far fewer comments in it that Claude has written. I left in as I thought it make reviewing a tad easier.

Everything below this line and the other two PRs (crash diagnostics PR, and the main smooth scrolling PR) are from Claude.




### Summary

The composer process leaks one `sync_file` fd per rendered frame in the
compositing window modes whenever SurfaceFlinger sends skipped layers (which
it does on every frame of normal app use). After a few minutes of continuous
rendering the process hits `RLIMIT_NOFILE`, the Wayland connection dies with
EMFILE, `hwc_wayland_thread` aborts by design, and the whole session goes
down. Measured on a 120Hz host: ~28,000 leaked fds in an 8-minute session;
with these fixes the process holds steady at ~108 fds under the same load.

### Root cause

The framebuffer target is drawn — and its acquire fence closed — at the
first skipped layer's position in `handle_layer`. But `hwc_set` only routed
layers with a buffer handle to the mode, and skipped layers usually carry
none, so the draw never ran; the framebuffer target's own branch then
skipped its close on the grounds that the draw site had done it. Since
`HWC2On1Adapter` hands the HAL a fresh `dup()` of the client target fence on
every `set()`, one fd leaked per frame. A second symptom of the same bug:
the client-composited content (everything SurfaceFlinger rendered into the
target for the skipped range) was silently never displayed.

### Changes

1. `hwcomposer: Close the cursor layer's acquire fence when not rendering it`
   — the non-subsurface cursor handler drops the fence entirely when no
   `wl_pointer` is bound (regression from the cursor handler rework; the
   subsurface handler kept the matching close).
2. `hwcomposer: Fix framebuffer target fence leak, sweep unclosed fences`
   — route every non-cursor layer through the mode (all modes already
   tolerate handle-less layers and close their fences;
   `multi_window_mode::can_handle_layer` now requires a handle explicitly),
   close the target's fence in the non-compositing modes on frames where it
   is not drawn, and add an end-of-`hwc_set` sweep that closes and reports
   (rate-limited) any fence every other path missed, so a future regression
   degrades to a log line instead of a session crash. All close sites now
   reset `acquireFenceFd` to -1, which is what makes the sweep sound.

### Behavior change to be aware of

Because the framebuffer target now actually renders when skipped layers are
present, client-composited content that was previously (incorrectly)
invisible now shows: most noticeably Android's app-launch dim scrim briefly
appears behind freeform windows during launch animations. This is faithful
to what SurfaceFlinger requests; noting it since users may notice the
difference.

### Testing

- Verified on lineage-20 x86_64 under KWin (Plasma, 120Hz laptop): fd count
  of the composer process flat at ~108 during minutes of continuous
  scrolling/fling rendering vs. ~28,000-and-climbing before; sweep log
  count is zero.
- The leak and the fix were confirmed with in-HAL instrumentation logging
  the layer type/flags/fence at every FBT-relevant branch (removed again in
  the final commits).
