### PR TITLE
audio: honour the format and rate AudioFlinger requests

### DIFF
--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -286,13 +286,14 @@ static audio_channel_mask_t out_get_channels(const struct audio_stream *stream)
     return audio_channel_out_mask_from_count(out->config.channels);
 }
 
-/* Converts audio_format to pcm_format.
+/* Converts audio_format to pcm_format without aborting.
  * Parameters:
  *  format  the audio_format_t to convert
  *
- * Logs a fatal error if format is not a valid convertible audio_format_t.
+ * Returns SND_PCM_FORMAT_UNKNOWN if format is not a valid convertible
+ * audio_format_t, so a caller can probe a format before committing to it.
  */
-static inline snd_pcm_format_t pcm_format_from_audio_format(audio_format_t format)
+static inline snd_pcm_format_t pcm_format_from_audio_format_safe(audio_format_t format)
 {
     switch (format) {
 #if HAVE_BIG_ENDIAN
@@ -319,9 +320,24 @@ static inline snd_pcm_format_t pcm_format_from_audio_format(audio_format_t forma
         return SND_PCM_FORMAT_FLOAT_LE;
 #endif
     default:
+        return SND_PCM_FORMAT_UNKNOWN;
+    }
+}
+
+/* Converts audio_format to pcm_format.
+ * Parameters:
+ *  format  the audio_format_t to convert
+ *
+ * Logs a fatal error if format is not a valid convertible audio_format_t.
+ */
+static inline snd_pcm_format_t pcm_format_from_audio_format(audio_format_t format)
+{
+    snd_pcm_format_t pcm_format = pcm_format_from_audio_format_safe(format);
+    if (pcm_format == SND_PCM_FORMAT_UNKNOWN) {
         LOG_ALWAYS_FATAL("pcm_format_from_audio_format: invalid audio format %#x", format);
         return 0;
     }
+    return pcm_format;
 }
 
 /* Converts pcm_format to audio_format.
@@ -800,6 +816,7 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
 
     struct alsa_audio_device *ladev = (struct alsa_audio_device *)dev;
     struct alsa_stream_out *out;
+    snd_pcm_format_t req_format;
     int ret = 0;
 
     out = (struct alsa_stream_out *)calloc(1, sizeof(struct alsa_stream_out));
@@ -825,14 +842,23 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
     out->stream.get_next_write_timestamp = out_get_next_write_timestamp;
 
     out->config.channels = CHANNEL_STEREO;
-    out->config.rate = PLAYBACK_CODEC_SAMPLING_RATE;
-    out->config.format = SND_PCM_FORMAT_S16_LE;
     out->config.period_size = PLAYBACK_PERIOD_SIZE;
     out->config.period_count = PLAYBACK_PERIOD_COUNT;
 
-    if (out->config.rate != config->sample_rate ||
+    /* Use the format and rate AudioFlinger asked for instead of forcing every
+     * stream to S16_LE/48000. Probe with the non-fatal converter: a format
+     * outside the table still aborts. A rate of zero means the caller has no
+     * preference, so use the default.
+     */
+    req_format = pcm_format_from_audio_format_safe(config->format);
+    out->config.format = (req_format != SND_PCM_FORMAT_UNKNOWN) ? req_format
+                                                                : SND_PCM_FORMAT_S16_LE;
+    out->config.rate = (config->sample_rate != 0) ? config->sample_rate
+                                                  : PLAYBACK_CODEC_SAMPLING_RATE;
+
+    if (req_format == SND_PCM_FORMAT_UNKNOWN ||
            audio_channel_count_from_out_mask(config->channel_mask) != CHANNEL_STEREO ||
-               out->config.format !=  pcm_format_from_audio_format(config->format) ) {
+               out->config.rate != config->sample_rate) {
         config->sample_rate = out->config.rate;
         config->format = audio_format_from_pcm_format(out->config.format);
         config->channel_mask = audio_channel_out_mask_from_count(CHANNEL_STEREO);

--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -304,6 +304,8 @@ static inline snd_pcm_format_t pcm_format_from_audio_format(audio_format_t forma
         return SND_PCM_FORMAT_S32_BE;
     case AUDIO_FORMAT_PCM_8_24_BIT:
         return SND_PCM_FORMAT_S24_BE;
+    case AUDIO_FORMAT_PCM_FLOAT:
+        return SND_PCM_FORMAT_FLOAT_BE;
 #else
     case AUDIO_FORMAT_PCM_16_BIT:
         return SND_PCM_FORMAT_S16_LE;
@@ -313,8 +315,9 @@ static inline snd_pcm_format_t pcm_format_from_audio_format(audio_format_t forma
         return SND_PCM_FORMAT_S32_LE;
     case AUDIO_FORMAT_PCM_8_24_BIT:
         return SND_PCM_FORMAT_S24_LE;
+    case AUDIO_FORMAT_PCM_FLOAT:
+        return SND_PCM_FORMAT_FLOAT_LE;
 #endif
-    case AUDIO_FORMAT_PCM_FLOAT:  /* there is no equivalent for float */
     default:
         LOG_ALWAYS_FATAL("pcm_format_from_audio_format: invalid audio format %#x", format);
         return 0;
@@ -339,6 +342,8 @@ static audio_format_t audio_format_from_pcm_format(snd_pcm_format_t format)
         return AUDIO_FORMAT_PCM_8_24_BIT;
     case SND_PCM_FORMAT_S32_BE:
         return AUDIO_FORMAT_PCM_32_BIT;
+    case SND_PCM_FORMAT_FLOAT_BE:
+        return AUDIO_FORMAT_PCM_FLOAT;
 #else
     case SND_PCM_FORMAT_S16_LE:
         return AUDIO_FORMAT_PCM_16_BIT;
@@ -348,6 +353,8 @@ static audio_format_t audio_format_from_pcm_format(snd_pcm_format_t format)
         return AUDIO_FORMAT_PCM_8_24_BIT;
     case SND_PCM_FORMAT_S32_LE:
         return AUDIO_FORMAT_PCM_32_BIT;
+    case SND_PCM_FORMAT_FLOAT_LE:
+        return AUDIO_FORMAT_PCM_FLOAT;
 #endif
     default:
         LOG_ALWAYS_FATAL("audio_format_from_pcm_format: invalid pcm format %#x", format);

--- a/audio/audio_policy_configuration.xml
+++ b/audio/audio_policy_configuration.xml
@@ -28,8 +28,9 @@
             <defaultOutputDevice>Speaker</defaultOutputDevice>
             <mixPorts>
                 <mixPort name="primary output" role="source" flags="AUDIO_OUTPUT_FLAG_PRIMARY">
-                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
+                    <profile name="" format="AUDIO_FORMAT_PCM_FLOAT"
+                             samplingRates="44100,48000,88200,96000,176400,192000"
+                             channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
                 <mixPort name="primary input" role="sink">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"


### PR DESCRIPTION
## The problem

`adev_open_output_stream()` hardcodes every output stream to `S16_LE` at
`PLAYBACK_CODEC_SAMPLING_RATE`:

```c
out->config.rate = PLAYBACK_CODEC_SAMPLING_RATE;
out->config.format = SND_PCM_FORMAT_S16_LE;
```

and `pcm_format_from_audio_format()` treats float as unrepresentable:

```c
case AUDIO_FORMAT_PCM_FLOAT:  /* there is no equivalent for float */
default:
    LOG_ALWAYS_FATAL(...)
```

ALSA does have an equivalent — `SND_PCM_FORMAT_FLOAT_LE`/`_BE`. Because of the
`LOG_ALWAYS_FATAL`, the format could not even be *tested* against the table
without aborting audioserver, so the comparison in `adev_open_output_stream()`
had to be arranged to never pass float in.

The effect is that everything the container plays is resampled to one rate and
truncated to 16-bit before it reaches the host. 44.1kHz content is resampled to
48kHz just as hi-res is.

The renegotiation branch does not rescue this. It sets `ret = -EINVAL` and
writes a corrected config back, but the function ends in `return 0`, so the
error is discarded (pre-existing, untouched by this PR). Even if it were
returned, `AudioHwDevice::openOutputStream()` calls the HAL once and carries a
`FIXME` acknowledging it ignores the config that comes back. There is no retry,
so the first call has to be the one that matches.

## The change

Two commits:

**1. Map `AUDIO_FORMAT_PCM_FLOAT` to `SND_PCM_FORMAT_FLOAT_*`.** Adds the
missing cases in both directions. The conversion is split into
`pcm_format_from_audio_format_safe()`, which returns
`SND_PCM_FORMAT_UNKNOWN` for anything unconvertible, and the original
`pcm_format_from_audio_format()`, now a wrapper that keeps the fatal contract
for existing callers — `adev_open_input_stream()` still aborts exactly as
before. Nothing that relied on the old behaviour changes.

**2. Open output streams at the requested format and rate.** Uses the probe to
take AudioFlinger's format when it is one the table knows, falling back to
`S16_LE` otherwise, and takes its rate unless it is zero. `snd_pcm_hw_params`
still negotiates, so an unsupported rate snaps to the nearest the backend
offers rather than failing.

The policy XML widens `primary output` to advertise float and the standard
family of rates, since the HAL can now honour them.

Deliberately not included: a `DIRECT` mix port. I tried one first, assuming
hi-res needed to bypass the mixer. It is not necessary — the primary output
carries 192kHz once the HAL stops overriding the request — so it is not here.

## Testing

x86_64, Waydroid on lineage-20, an iFi USB DAC via PipeWire, playing 24/192
content.

Before, at the host ALSA device:

```
format: S16_LE
rate:   48000
```

After:

```
format: S32_LE
rate:   192000 (192000/1)
Momentary freq = 192002 Hz (0x18.0010)
```

The USB feedback value is the endpoint's own clock reporting lock at the
requested rate, so this is the hardware confirming it, not a software claim.
44.1kHz content now also arrives as 44100 rather than being resampled to 48000.

## What I have not tested

- **Big-endian.** The `_BE` cases mirror the existing `_BE` entries around them
  but were never executed.
- **ARM.** Built and run only on x86_64.
- **Input streams.** Untouched, and `adev_open_input_stream()` keeps the fatal
  converter.
- **Devices that report a narrow rate set.** Negotiation should snap to the
  nearest supported rate, but I only have hardware that accepts the full range.

One consequence worth flagging: advertising float means AudioFlinger stops
converting to 16-bit itself and hands float through, so the mixer output format
genuinely changes rather than merely widening. On a backend that cannot do
float, `snd_pcm_hw_params` refuses and the stream fails to open — which is the
case I cannot exercise here and would most want review on.
